### PR TITLE
Separate queryable object

### DIFF
--- a/src/CouchDB.Client/CouchDocuments.cs
+++ b/src/CouchDB.Client/CouchDocuments.cs
@@ -15,7 +15,7 @@ using Newtonsoft.Json;
 
 namespace CouchDB.Client
 {
-    public class CouchDocuments<TSource> : IAscendingOrderedCouchQueryable<TSource>, IDescendingOrderedCouchQueryable<TSource> where TSource : CouchEntity
+    public class CouchDocuments<TSource> : ICouchQueryable<TSource> where TSource : CouchEntity
     {
         private readonly CouchDatabase<TSource> _db;
 
@@ -72,223 +72,106 @@ namespace CouchDB.Client
 
         #region Where
 
-        public bool StatsEnabled { get; private set; }
-        public string LastBookmark { get; private set; }
-        public ExecutionStats LastExecutionStats { get; private set; }
-        
         #region Selector
 
-        private IDictionary<string, object> _selector;
         public ICouchQueryable<TSource> Where(Expression<Func<TSource, bool>> predicate)
         {
-            _selector = SelectorObjectBuilder.Serialize(predicate);
-            return this;
+            return new CouchQueryable<TSource>(_db, predicate);
         }
 
         #endregion
-       
+
         #region Limit
 
-        private int? _takeCount;
         public ICouchQueryable<TSource> Take(int count)
         {
-            if (count <= 0) throw new ArgumentException("Cannot take a not positive number of documents.");
-            _takeCount = count;
-            return this;
+            return new CouchQueryable<TSource>(_db).Take(count);
         }
 
         #endregion
 
         #region Skip
 
-        private int? _skipCount;
         public ICouchQueryable<TSource> Skip(int count)
         {
-            if (count < 0) throw new ArgumentException("Cannot skip a negative number of documents,");
-            _skipCount = count;
-            return this;
+            return new CouchQueryable<TSource>(_db).Skip(count);
         }
 
         #endregion
-       
-        #region Sort
 
-        private List<SortProperty> _sortProperties;
+        #region Sort
 
         public IAscendingOrderedCouchQueryable<TSource> OrderBy<TProperty>(Expression<Func<TSource, TProperty>> keySelector)
         {
-            var propName = keySelector.GetJsonPropertyName();
-            _sortProperties = new List<SortProperty> { new SortProperty(propName, true) };
-            return this;
-        }
-
-        public IAscendingOrderedCouchQueryable<TSource> ThenBy<TProperty>(Expression<Func<TSource, TProperty>> keySelector)
-        {
-            var propName = keySelector.GetJsonPropertyName();
-            _sortProperties.Add(new SortProperty(propName, true));
-            return this;
+            return new CouchQueryable<TSource>(_db).OrderBy(keySelector);
         }
 
         public IDescendingOrderedCouchQueryable<TSource> OrderByDescending<TProperty>(Expression<Func<TSource, TProperty>> keySelector)
         {
-            var propName = keySelector.GetJsonPropertyName();
-            _sortProperties = new List<SortProperty> { new SortProperty(propName, false) };
-            return this;
-        }
-
-        public IDescendingOrderedCouchQueryable<TSource> ThenByDescending<TProperty>(Expression<Func<TSource, TProperty>> keySelector)
-        {
-            var propName = keySelector.GetJsonPropertyName();
-            _sortProperties.Add(new SortProperty(propName, false));
-            return this;
+            return new CouchQueryable<TSource>(_db).OrderByDescending(keySelector);
         }
 
         #endregion
 
         #region Fields
 
-        private List<string> _fields;
         public ICouchQueryable<TSource> Select(params Expression<Func<TSource, object>>[] fieldSelectors)
         {
-            _fields = new List<string>();
-            foreach (var fieldSelector in fieldSelectors)
-            {
-                var property = fieldSelector.GetJsonPropertyName();
-                _fields.Add(property);
-            }
-            return this;
+            return new CouchQueryable<TSource>(_db).Select(fieldSelectors);
         }
 
         #endregion
 
         #region R
 
-        private int? _quorum;
         public ICouchQueryable<TSource> WithReadQuorum(int count)
         {
-            if (count <= 0) throw new ArgumentException("Cannot set a not positive quorum count.");
-            _quorum = count;
-            return this;
+            return new CouchQueryable<TSource>(_db).WithReadQuorum(count);
         }
 
         #endregion
 
         #region Bookmark
 
-        private string _bookmarkToUse;
         public ICouchQueryable<TSource> UseBookmark(string bookmark)
         {
-            _bookmarkToUse = bookmark ?? throw new ArgumentNullException(nameof(bookmark));
-            return this;
+            return new CouchQueryable<TSource>(_db).UseBookmark(bookmark);
         }
 
         #endregion
 
         #region Update
 
-        private bool? _updateIndex;
         public ICouchQueryable<TSource> UpdateIndex()
         {
-            _updateIndex = true;
-            return this;
+            return new CouchQueryable<TSource>(_db).UpdateIndex();
         }
 
         #endregion
 
         #region Stable
 
-        private bool? _fromStable;
         public ICouchQueryable<TSource> FromStable()
         {
-            _fromStable = true;
-            return this;
+            return new CouchQueryable<TSource>(_db).FromStable();
         }
 
         #endregion
 
         #region Stats
 
-        public void EnableStats(bool enabled = true)
+        public ICouchQueryable<TSource> WithExecutionStats()
         {
-            StatsEnabled = enabled;
+            return new CouchQueryable<TSource>(_db).WithExecutionStats();
         }
 
         #endregion
 
         #region Request
 
-        public async Task<List<TSource>> ToListAsync()
+        public Task<List<TSource>> ToListAsync()
         {
-            var findQuery = new Dictionary<string, object>();
-
-            if (_selector == null)
-            {
-                var greaterThanNull = new ExpandoObject();
-                greaterThanNull.AddProperty("$gt", null);
-                var emptySelector = new ExpandoObject();
-                emptySelector.AddProperty("_id", greaterThanNull);
-                _selector = emptySelector;
-            }
-
-            findQuery.Add("selector", _selector);
-
-            if (_takeCount.HasValue)
-                findQuery.Add("limit", _takeCount.Value);
-            if (_skipCount.HasValue)
-                findQuery.Add("skip", _skipCount.Value);
-            if (_sortProperties != null)
-                findQuery.Add("sort", _sortProperties.Select(s => new Dictionary<string, string> {{s.Name, s.Direction}}));
-            if (_fields != null)
-                findQuery.Add("fields", _fields);
-            if (_quorum.HasValue)
-                findQuery.Add("r", _quorum.Value);
-            if (_bookmarkToUse != null)
-                findQuery.Add("bookmark", _bookmarkToUse);
-            if (_updateIndex.HasValue)
-                findQuery.Add("update", true);
-            if (_fromStable.HasValue)
-                findQuery.Add("stable", true);
-            if (StatsEnabled)
-                findQuery.Add("execution_stats", true);
-
-            var jsonRequest = JsonConvert.SerializeObject(findQuery);
-
-            var result = await _db.NewDbRequest()
-                .AppendPathSegment("_find")
-                .PostJsonAsync(findQuery)
-                .ReceiveJson<ListResult>();
-
-            ResetQueryParameters();
-            LastBookmark = result.Bookmark;
-            LastExecutionStats = result.ExecutionStats;
-
-            return result.Docs;
-        }
-
-        private class ListResult
-        {
-            [JsonProperty("docs")]
-            public List<TSource> Docs { get; set; }
-            [JsonProperty("bookmark")]
-            public string Bookmark { get; set; }
-            [JsonProperty("execution_stats")]
-            public ExecutionStats ExecutionStats { get; set; }
-        }
-
-        private void ResetQueryParameters()
-        {
-            LastBookmark = null;
-            LastExecutionStats = null;
-
-            _selector = null;
-            _takeCount = null;
-            _skipCount = null;
-            _sortProperties = null;
-            _fields = null;
-            _quorum = null;
-            _bookmarkToUse = null;
-            _updateIndex = null;
-            _fromStable = null;
+            return new CouchQueryable<TSource>(_db).ToListAsync();
         }
 
         #endregion
@@ -328,7 +211,7 @@ namespace CouchDB.Client
         public async Task UpdateRangeAsync(IEnumerable<TSource> documents)
         {
             await _db.NewDbRequest()
-                .AppendPathSegment("_buld_docs")
+                .AppendPathSegment("_bulk_docs")
                 .PostJsonAsync(new { docs = documents })
                 .SendAsync();
         }

--- a/src/CouchDB.Client/CouchQueryable.cs
+++ b/src/CouchDB.Client/CouchQueryable.cs
@@ -1,0 +1,192 @@
+﻿using CouchDB.Client.Query;
+using CouchDB.Client.Query.Extensions;
+using CouchDB.Client.Query.Selector;
+using CouchDB.Client.Query.Sort;
+using Flurl.Http;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Dynamic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CouchDB.Client
+{
+    public class CouchQueryable<TSource> : IAscendingOrderedCouchQueryable<TSource>, IDescendingOrderedCouchQueryable<TSource> where TSource : CouchEntity
+    {
+        private readonly CouchDatabase<TSource> _db;
+        public CouchQueryable(CouchDatabase<TSource> db)
+        {
+            _db = db;
+        }
+
+        public CouchQueryable(CouchDatabase<TSource> db, Expression<Func<TSource, bool>> predicate) : this(db)
+        {
+            Where(predicate);
+        }
+
+        private IDictionary<string, object> _selector;
+        private ICouchQueryable<TSource> Where(Expression<Func<TSource, bool>> predicate)
+        {
+            // Can only use 1 where, so keep it private
+            _selector = SelectorObjectBuilder.Serialize(predicate);
+            return this;
+        }
+
+        private List<SortProperty> _sortProperties;
+        public IAscendingOrderedCouchQueryable<TSource> OrderBy<TProperty>(Expression<Func<TSource, TProperty>> keySelector)
+        {
+            var propName = keySelector.GetJsonPropertyName();
+            _sortProperties = new List<SortProperty> { new SortProperty(propName, true) };
+            return this;
+        }
+
+        public IDescendingOrderedCouchQueryable<TSource> OrderByDescending<TProperty>(Expression<Func<TSource, TProperty>> keySelector)
+        {
+            var propName = keySelector.GetJsonPropertyName();
+            _sortProperties = new List<SortProperty> { new SortProperty(propName, false) };
+            return this;
+        }
+
+        public IAscendingOrderedCouchQueryable<TSource> ThenBy<TProperty>(Expression<Func<TSource, TProperty>> keySelector)
+        {
+            var propName = keySelector.GetJsonPropertyName();
+            _sortProperties.Add(new SortProperty(propName, true));
+            return this;
+        }
+
+        public IDescendingOrderedCouchQueryable<TSource> ThenByDescending<TProperty>(Expression<Func<TSource, TProperty>> keySelector)
+        {
+            var propName = keySelector.GetJsonPropertyName();
+            _sortProperties.Add(new SortProperty(propName, false));
+            return this;
+        }
+
+        private List<string> _fields;
+        public ICouchQueryable<TSource> Select(params Expression<Func<TSource, object>>[] fieldSelectors)
+        {
+            _fields = new List<string>();
+            foreach (var fieldSelector in fieldSelectors)
+            {
+                var property = fieldSelector.GetJsonPropertyName();
+                _fields.Add(property);
+            }
+            return this;
+        }
+
+        private int? _skipCount;
+        public ICouchQueryable<TSource> Skip(int count)
+        {
+            if (count < 0) throw new ArgumentException("Cannot skip a negative number of documents,");
+            _skipCount = count;
+            return this;
+        }
+
+        private int? _takeCount;
+        public ICouchQueryable<TSource> Take(int count)
+        {
+            if (count <= 0) throw new ArgumentException("Cannot take a not positive number of documents.");
+            _takeCount = count;
+            return this;
+        }
+
+        private bool? _updateIndex;
+        public ICouchQueryable<TSource> UpdateIndex()
+        {
+            _updateIndex = true;
+            return this;
+        }
+
+        private bool? _fromStable;
+        public ICouchQueryable<TSource> FromStable()
+        {
+            _fromStable = true;
+            return this;
+        }
+
+        private bool _statsEnabled;
+        public ICouchQueryable<TSource> WithExecutionStats()
+        {
+            _statsEnabled = true;
+            return this;
+        }
+
+        private string _bookmarkToUse;
+        public ICouchQueryable<TSource> UseBookmark(string bookmark)
+        {
+            _bookmarkToUse = bookmark ?? throw new ArgumentNullException(nameof(bookmark));
+            return this;
+        }
+
+        private int? _quorum;
+
+        public object LastBookmark { get; private set; }
+        public object LastExecutionStats { get; private set; }
+
+        public ICouchQueryable<TSource> WithReadQuorum(int count)
+        {
+            if (count <= 0) throw new ArgumentException("Cannot set a not positive quorum count.");
+            _quorum = count;
+            return this;
+        }
+
+        public async Task<List<TSource>> ToListAsync()
+        {
+            var findQuery = new Dictionary<string, object>();
+
+            if (_selector == null)
+            {
+                var greaterThanNull = new ExpandoObject();
+                greaterThanNull.AddProperty("$gt", null);
+                var emptySelector = new ExpandoObject();
+                emptySelector.AddProperty("_id", greaterThanNull);
+                _selector = emptySelector;
+            }
+
+            findQuery.Add("selector", _selector);
+
+            if (_takeCount.HasValue)
+                findQuery.Add("limit", _takeCount.Value);
+            if (_skipCount.HasValue)
+                findQuery.Add("skip", _skipCount.Value);
+            if (_sortProperties != null)
+                findQuery.Add("sort", _sortProperties.Select(s => new Dictionary<string, string> { { s.Name, s.Direction } }));
+            if (_fields != null)
+                findQuery.Add("fields", _fields);
+            if (_quorum.HasValue)
+                findQuery.Add("r", _quorum.Value);
+            if (_bookmarkToUse != null)
+                findQuery.Add("bookmark", _bookmarkToUse);
+            if (_updateIndex.HasValue)
+                findQuery.Add("update", true);
+            if (_fromStable.HasValue)
+                findQuery.Add("stable", true);
+            if (_statsEnabled)
+                findQuery.Add("execution_stats", true);
+
+            var jsonRequest = JsonConvert.SerializeObject(findQuery);
+
+            var result = await _db.NewDbRequest()
+                .AppendPathSegment("_find")
+                .PostJsonAsync(findQuery)
+                .ReceiveJson<ListResult>();
+
+            LastBookmark = result.Bookmark;
+            LastExecutionStats = result.ExecutionStats;
+
+            return result.Docs;
+        }
+
+        private class ListResult
+        {
+            [JsonProperty("docs")]
+            public List<TSource> Docs { get; set; }
+            [JsonProperty("bookmark")]
+            public string Bookmark { get; set; }
+            [JsonProperty("execution_stats")]
+            public ExecutionStats ExecutionStats { get; set; }
+        }
+    }
+}

--- a/src/CouchDB.Client/Query/ICouchQueryable.cs
+++ b/src/CouchDB.Client/Query/ICouchQueryable.cs
@@ -17,6 +17,7 @@ namespace CouchDB.Client.Query
         ICouchQueryable<TSource> Select(params Expression<Func<TSource, object>>[] fieldSelectors);
         ICouchQueryable<TSource> Skip(int count);
         ICouchQueryable<TSource> Take(int count);
+        ICouchQueryable<TSource> WithExecutionStats();
         ICouchQueryable<TSource> WithReadQuorum(int quorum);
         ICouchQueryable<TSource> UseBookmark(string bookmark);
         ICouchQueryable<TSource> UpdateIndex();


### PR DESCRIPTION
I ran into a case where I built 2 queries before executing them, but the 2nd one overwrote the 1st. I split the query properties out into a dedicated `Queryable` object so multiple queries don't step on each other