### PR TITLE
Refresh auth token when it expires, not when it hasn't expired

### DIFF
--- a/src/CouchDB.Client/CouchClient.cs
+++ b/src/CouchDB.Client/CouchClient.cs
@@ -30,7 +30,7 @@ namespace CouchDB.Client
         internal IFlurlRequest NewRequest()
         {
             if (_authData.NeedAuthentication && (_authData.AuthToken == null ||
-                                                 _authData.AuthTokenDate.AddMinutes(_authData.AuthTokenDuration) >=
+                                                 _authData.AuthTokenDate.AddMinutes(_authData.AuthTokenDuration) <
                                                  DateTime.Now))
                 Login().Wait();
 
@@ -50,7 +50,7 @@ namespace CouchDB.Client
         }
 
         #region Authentication
-        
+
         public void ConfigureAuthentication(string name, string password, int tokenDurationMinutes = 10)
         {
             _authData.NeedAuthentication = true;


### PR DESCRIPTION
Every request was generating a new login request instead of reusing the auth token because the expiration check was backwards