### PR TITLE
Remove client cert validation

### DIFF
--- a/src/CouchDB.Client/CouchClient.cs
+++ b/src/CouchDB.Client/CouchClient.cs
@@ -60,17 +60,6 @@ namespace CouchDB.Client
             _flurlClient = FlurlHttp.GlobalSettings.FlurlClientFactory.Get(_serverUrl);
         }
 
-        public Func<HttpRequestMessage, X509Certificate2, X509Chain, SslPolicyErrors, bool> ServerCertificateCustomValidationCallback
-        {
-            set
-            {
-                if (_flurlClient.HttpMessageHandler is HttpClientHandler httpClientHandler)
-                {
-                    httpClientHandler.ServerCertificateCustomValidationCallback = value;
-                }
-            }
-        }
-
         #region Authentication
 
         public void ConfigureAuthentication(string name, string password, int tokenDurationMinutes = 10)


### PR DESCRIPTION
Removes client cert validation added by #1. It doesn't work if you need to recreate a client. A better approach is to configure it using Flurl from the calling application.

```
FlurlHttp.ConfigureClient(serverUri.ToString(), c =>
{
    c.Settings.HttpClientFactory = new CertClientFactory();
});

public class OcuveraCertClientFactory : DefaultHttpClientFactory
{
    public override HttpMessageHandler CreateMessageHandler()
    {
        return new HttpClientHandler()
        {
            ServerCertificateCustomValidationCallback = (message, cert, chain, errors) =>
            {
                // TODO Implement actual cert validation
                return true;
            }
        };
    }
}
```