### PR TITLE
SelectorBuilder tests and tweaks

### DIFF
--- a/src/CouchDB.Client.Tests/CouchDB.Client.Tests.csproj
+++ b/src/CouchDB.Client.Tests/CouchDB.Client.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="5.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\CouchDB.Client\CouchDB.Client.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/CouchDB.Client.Tests/SelectorTests.cs
+++ b/src/CouchDB.Client.Tests/SelectorTests.cs
@@ -324,5 +324,53 @@ namespace CouchDB.Client.Tests
 
             jsonRequest.Should().Be("{\"MyInt\":{\"$lte\":1}}");
         }
+
+        [TestMethod]
+        public void NotGreaterThanTest()
+        {
+            Expression<Func<MyDocument, bool>> query = t => !(t.MyInt > comparisonDoc.MyInt);
+
+            var selector = SelectorObjectBuilder.Serialize<MyDocument>(query);
+
+            var jsonRequest = JsonConvert.SerializeObject(selector);
+
+            jsonRequest.Should().Be("{\"$not\":{\"MyInt\":{\"$gt\":1}}}");
+        }
+
+        [TestMethod]
+        public void OrTest()
+        {
+            Expression<Func<MyDocument, bool>> query = t => t.MyInt > 100 || t.MyInt < 10;
+
+            var selector = SelectorObjectBuilder.Serialize<MyDocument>(query);
+
+            var jsonRequest = JsonConvert.SerializeObject(selector);
+
+            jsonRequest.Should().Be("{\"$or\":[{\"MyInt\":{\"$gt\":100}},{\"MyInt\":{\"$lt\":10}}]}");
+        }
+
+        [TestMethod]
+        public void AndDifferentFieldsTest()
+        {
+            Expression<Func<MyDocument, bool>> query = t => t.MyInt > 100 && t.MyDoc.MyInt < 10;
+
+            var selector = SelectorObjectBuilder.Serialize<MyDocument>(query);
+
+            var jsonRequest = JsonConvert.SerializeObject(selector);
+
+            jsonRequest.Should().Be("{\"MyInt\":{\"$gt\":100},\"MyDoc.MyInt\":{\"$lt\":10}}");
+        }
+
+        [TestMethod]
+        public void AndSameFieldTest()
+        {
+            Expression<Func<MyDocument, bool>> query = t => t.MyInt > 10 && t.MyInt < 100;
+
+            var selector = SelectorObjectBuilder.Serialize<MyDocument>(query);
+
+            var jsonRequest = JsonConvert.SerializeObject(selector);
+
+            jsonRequest.Should().Be("{\"$and\":[{\"MyInt\":{\"$gt\":10}},{\"MyInt\":{\"$lt\":100}}]}");
+        }
     }
 }

--- a/src/CouchDB.Client.Tests/SelectorTests.cs
+++ b/src/CouchDB.Client.Tests/SelectorTests.cs
@@ -1,0 +1,280 @@
+using CouchDB.Client.Query.Selector;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using System;
+using System.Linq.Expressions;
+
+namespace CouchDB.Client.Tests
+{
+    [TestClass]
+    public class SelectorTests
+    {
+        class MyDocument : CouchEntity
+        {
+            public int MyInt { get; set; }
+
+            public MyDocument MyDoc { get; set; }
+        }
+
+        [TestMethod]
+        public void EqualsConstantTest()
+        {
+            Expression<Func<MyDocument, bool>> query = t => t.MyInt == 1;
+
+            var selector = SelectorObjectBuilder.Serialize<MyDocument>(query);
+
+            var jsonRequest = JsonConvert.SerializeObject(selector);
+
+            jsonRequest.Should().Be("{\"MyInt\":1}");
+        }
+
+        [TestMethod]
+        public void GreaterThanConstantTest()
+        {
+            Expression<Func<MyDocument, bool>> query = t => t.MyInt > 1;
+
+            var selector = SelectorObjectBuilder.Serialize<MyDocument>(query);
+
+            var jsonRequest = JsonConvert.SerializeObject(selector);
+
+            jsonRequest.Should().Be("{\"MyInt\":{\"$gt\":1}}");
+        }
+
+        [TestMethod]
+        public void GreaterThanOrEqualConstantTest()
+        {
+            Expression<Func<MyDocument, bool>> query = t => t.MyInt >= 1;
+
+            var selector = SelectorObjectBuilder.Serialize<MyDocument>(query);
+
+            var jsonRequest = JsonConvert.SerializeObject(selector);
+
+            jsonRequest.Should().Be("{\"MyInt\":{\"$gte\":1}}");
+        }
+
+        [TestMethod]
+        public void LessThanConstantTest()
+        {
+            Expression<Func<MyDocument, bool>> query = t => t.MyInt < 1;
+
+            var selector = SelectorObjectBuilder.Serialize<MyDocument>(query);
+
+            var jsonRequest = JsonConvert.SerializeObject(selector);
+
+            jsonRequest.Should().Be("{\"MyInt\":{\"$lt\":1}}");
+        }
+
+        [TestMethod]
+        public void LessThanOrEqualConstantTest()
+        {
+            Expression<Func<MyDocument, bool>> query = t => t.MyInt <= 1;
+
+            var selector = SelectorObjectBuilder.Serialize<MyDocument>(query);
+
+            var jsonRequest = JsonConvert.SerializeObject(selector);
+
+            jsonRequest.Should().Be("{\"MyInt\":{\"$lte\":1}}");
+        }
+
+        [TestMethod]
+        public void NestedEqualsConstantTest()
+        {
+            Expression<Func<MyDocument, bool>> query = t => t.MyDoc.MyInt == 1;
+
+            var selector = SelectorObjectBuilder.Serialize<MyDocument>(query);
+
+            var jsonRequest = JsonConvert.SerializeObject(selector);
+
+            jsonRequest.Should().Be("{\"MyDoc.MyInt\":1}");
+        }
+
+        [TestMethod]
+        public void NestedGreaterThanConstantTest()
+        {
+            Expression<Func<MyDocument, bool>> query = t => t.MyDoc.MyInt > 1;
+
+            var selector = SelectorObjectBuilder.Serialize<MyDocument>(query);
+
+            var jsonRequest = JsonConvert.SerializeObject(selector);
+
+            jsonRequest.Should().Be("{\"MyDoc.MyInt\":{\"$gt\":1}}");
+        }
+
+        [TestMethod]
+        public void NestedGreaterThanOrEqualConstantTest()
+        {
+            Expression<Func<MyDocument, bool>> query = t => t.MyDoc.MyInt >= 1;
+
+            var selector = SelectorObjectBuilder.Serialize<MyDocument>(query);
+
+            var jsonRequest = JsonConvert.SerializeObject(selector);
+
+            jsonRequest.Should().Be("{\"MyDoc.MyInt\":{\"$gte\":1}}");
+        }
+
+        [TestMethod]
+        public void NestedLessThanConstantTest()
+        {
+            Expression<Func<MyDocument, bool>> query = t => t.MyDoc.MyInt < 1;
+
+            var selector = SelectorObjectBuilder.Serialize<MyDocument>(query);
+
+            var jsonRequest = JsonConvert.SerializeObject(selector);
+
+            jsonRequest.Should().Be("{\"MyDoc.MyInt\":{\"$lt\":1}}");
+        }
+
+        [TestMethod]
+        public void NestedLessThanOrEqualConstantTest()
+        {
+            Expression<Func<MyDocument, bool>> query = t => t.MyDoc.MyInt <= 1;
+
+            var selector = SelectorObjectBuilder.Serialize<MyDocument>(query);
+
+            var jsonRequest = JsonConvert.SerializeObject(selector);
+
+            jsonRequest.Should().Be("{\"MyDoc.MyInt\":{\"$lte\":1}}");
+        }
+
+        int one = 1;
+
+        [TestMethod]
+        public void EqualsVariableTest()
+        {
+            Expression<Func<MyDocument, bool>> query = t => t.MyInt == one;
+
+            var selector = SelectorObjectBuilder.Serialize<MyDocument>(query);
+
+            var jsonRequest = JsonConvert.SerializeObject(selector);
+
+            jsonRequest.Should().Be("{\"MyInt\":1}");
+        }
+
+        [TestMethod]
+        public void GreaterThanVariableTest()
+        {
+            Expression<Func<MyDocument, bool>> query = t => t.MyInt > one;
+
+            var selector = SelectorObjectBuilder.Serialize<MyDocument>(query);
+
+            var jsonRequest = JsonConvert.SerializeObject(selector);
+
+            jsonRequest.Should().Be("{\"MyInt\":{\"$gt\":1}}");
+        }
+
+        [TestMethod]
+        public void GreaterThanOrEqualVariableTest()
+        {
+            Expression<Func<MyDocument, bool>> query = t => t.MyInt >= one;
+
+            var selector = SelectorObjectBuilder.Serialize<MyDocument>(query);
+
+            var jsonRequest = JsonConvert.SerializeObject(selector);
+
+            jsonRequest.Should().Be("{\"MyInt\":{\"$gte\":1}}");
+        }
+
+        [TestMethod]
+        public void LessThanVariableTest()
+        {
+            Expression<Func<MyDocument, bool>> query = t => t.MyInt < one;
+
+            var selector = SelectorObjectBuilder.Serialize<MyDocument>(query);
+
+            var jsonRequest = JsonConvert.SerializeObject(selector);
+
+            jsonRequest.Should().Be("{\"MyInt\":{\"$lt\":1}}");
+        }
+
+        [TestMethod]
+        public void LessThanOrEqualVariableTest()
+        {
+            Expression<Func<MyDocument, bool>> query = t => t.MyInt <= one;
+
+            var selector = SelectorObjectBuilder.Serialize<MyDocument>(query);
+
+            var jsonRequest = JsonConvert.SerializeObject(selector);
+
+            jsonRequest.Should().Be("{\"MyInt\":{\"$lte\":1}}");
+        }
+
+        MyDocument comparisonDoc = new MyDocument()
+        {
+            MyInt = 1
+        };
+
+        [TestMethod]
+        public void EqualsObjectPropertyTest()
+        {
+            Expression<Func<MyDocument, bool>> query = t => t.MyInt == comparisonDoc.MyInt;
+
+            var selector = SelectorObjectBuilder.Serialize<MyDocument>(query);
+
+            var jsonRequest = JsonConvert.SerializeObject(selector);
+
+            jsonRequest.Should().Be("{\"MyInt\":1}");
+        }
+
+        [TestMethod]
+        public void GreaterThanObjectPropertyTest()
+        {
+            Expression<Func<MyDocument, bool>> query = t => t.MyInt > comparisonDoc.MyInt;
+
+            var selector = SelectorObjectBuilder.Serialize<MyDocument>(query);
+
+            var jsonRequest = JsonConvert.SerializeObject(selector);
+
+            jsonRequest.Should().Be("{\"MyInt\":{\"$gt\":1}}");
+        }
+
+        [TestMethod]
+        public void GreaterThanOrEqualObjectPropertyTest()
+        {
+            Expression<Func<MyDocument, bool>> query = t => t.MyInt >= comparisonDoc.MyInt;
+
+            var selector = SelectorObjectBuilder.Serialize<MyDocument>(query);
+
+            var jsonRequest = JsonConvert.SerializeObject(selector);
+
+            jsonRequest.Should().Be("{\"MyInt\":{\"$gte\":1}}");
+        }
+
+        [TestMethod]
+        public void LessThanObjectPropertyTest()
+        {
+            Expression<Func<MyDocument, bool>> query = t => t.MyInt < comparisonDoc.MyInt;
+
+            var selector = SelectorObjectBuilder.Serialize<MyDocument>(query);
+
+            var jsonRequest = JsonConvert.SerializeObject(selector);
+
+            jsonRequest.Should().Be("{\"MyInt\":{\"$lt\":1}}");
+        }
+
+        [TestMethod]
+        public void LessThanOrEqualObjectPropertyTest()
+        {
+            Expression<Func<MyDocument, bool>> query = t => t.MyInt <= comparisonDoc.MyInt;
+
+            var selector = SelectorObjectBuilder.Serialize<MyDocument>(query);
+
+            var jsonRequest = JsonConvert.SerializeObject(selector);
+
+            jsonRequest.Should().Be("{\"MyInt\":{\"$lte\":1}}");
+        }
+
+        [TestMethod]
+        public void LessThanOrEqualObjectPropertyTest_VeryNested()
+        {
+            comparisonDoc = new MyDocument() { MyDoc = new MyDocument() { MyDoc = comparisonDoc } };
+            Expression<Func<MyDocument, bool>> query = t => t.MyInt <= comparisonDoc.MyDoc.MyDoc.MyInt;
+
+            var selector = SelectorObjectBuilder.Serialize<MyDocument>(query);
+
+            var jsonRequest = JsonConvert.SerializeObject(selector);
+
+            jsonRequest.Should().Be("{\"MyInt\":{\"$lte\":1}}");
+        }
+    }
+}

--- a/src/CouchDB.Client.Tests/SelectorTests.cs
+++ b/src/CouchDB.Client.Tests/SelectorTests.cs
@@ -78,6 +78,18 @@ namespace CouchDB.Client.Tests
         }
 
         [TestMethod]
+        public void NotEqualConstantTest()
+        {
+            Expression<Func<MyDocument, bool>> query = t => t.MyInt != 1;
+
+            var selector = SelectorObjectBuilder.Serialize<MyDocument>(query);
+
+            var jsonRequest = JsonConvert.SerializeObject(selector);
+
+            jsonRequest.Should().Be("{\"MyInt\":{\"$ne\":1}}");
+        }
+
+        [TestMethod]
         public void NestedEqualsConstantTest()
         {
             Expression<Func<MyDocument, bool>> query = t => t.MyDoc.MyInt == 1;
@@ -135,6 +147,18 @@ namespace CouchDB.Client.Tests
             var jsonRequest = JsonConvert.SerializeObject(selector);
 
             jsonRequest.Should().Be("{\"MyDoc.MyInt\":{\"$lte\":1}}");
+        }
+
+        [TestMethod]
+        public void NestedNotEqualConstantTest()
+        {
+            Expression<Func<MyDocument, bool>> query = t => t.MyDoc.MyInt != 1;
+
+            var selector = SelectorObjectBuilder.Serialize<MyDocument>(query);
+
+            var jsonRequest = JsonConvert.SerializeObject(selector);
+
+            jsonRequest.Should().Be("{\"MyDoc.MyInt\":{\"$ne\":1}}");
         }
 
         int one = 1;
@@ -197,6 +221,18 @@ namespace CouchDB.Client.Tests
             var jsonRequest = JsonConvert.SerializeObject(selector);
 
             jsonRequest.Should().Be("{\"MyInt\":{\"$lte\":1}}");
+        }
+
+        [TestMethod]
+        public void NotEqualVariableTest()
+        {
+            Expression<Func<MyDocument, bool>> query = t => t.MyInt != one;
+
+            var selector = SelectorObjectBuilder.Serialize<MyDocument>(query);
+
+            var jsonRequest = JsonConvert.SerializeObject(selector);
+
+            jsonRequest.Should().Be("{\"MyInt\":{\"$ne\":1}}");
         }
 
         MyDocument comparisonDoc = new MyDocument()
@@ -262,6 +298,18 @@ namespace CouchDB.Client.Tests
             var jsonRequest = JsonConvert.SerializeObject(selector);
 
             jsonRequest.Should().Be("{\"MyInt\":{\"$lte\":1}}");
+        }
+
+        [TestMethod]
+        public void NotEqualObjectPropertyTest()
+        {
+            Expression<Func<MyDocument, bool>> query = t => t.MyInt != comparisonDoc.MyInt;
+
+            var selector = SelectorObjectBuilder.Serialize<MyDocument>(query);
+
+            var jsonRequest = JsonConvert.SerializeObject(selector);
+
+            jsonRequest.Should().Be("{\"MyInt\":{\"$ne\":1}}");
         }
 
         [TestMethod]

--- a/src/CouchDB.Client/Properties/AssemblyInfo.cs
+++ b/src/CouchDB.Client/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("CouchDB.Client.Tests")]

--- a/src/CouchDB.Client/Query/Selector/SelectorNodesBuilder.cs
+++ b/src/CouchDB.Client/Query/Selector/SelectorNodesBuilder.cs
@@ -51,28 +51,6 @@ namespace CouchDB.Client.Query.Selector
                 {
                     throw new NotImplementedException($"Expression.NodeType {currentExpression.NodeType} is not implemented");
                 }
-
-                //var nextExpression = memberExpr.Expression;
-
-                //if (nextExpression is ParameterExpression)
-                //{
-                //    return new MemberNode { Name = GetPropertyName(memberExpr.Member) };
-                //}
-                //else if (nextExpression is ConstantExpression)
-                //{
-                //    var value = Expression.Lambda(memberExpr).Compile().DynamicInvoke();
-                //    return new ConstantNode() { Value = value };
-                //}
-                //else
-                //{
-                //    var node = NewCouchNode(nextExpression);
-
-                //    if (node is MemberNode memberNode)
-                //    {
-                //        memberNode.Name += "." + GetPropertyName(memberExpr.Member);
-                //    }
-                //    return node;
-                //}
             }
             if (expr is ConstantExpression constantExpr)
             {

--- a/src/CouchDB.Client/Query/Selector/SelectorObjectBuilder.cs
+++ b/src/CouchDB.Client/Query/Selector/SelectorObjectBuilder.cs
@@ -29,7 +29,14 @@ namespace CouchDB.Client.Query.Selector
             {
                 var andSubChildren = andChild.Value as IEnumerable<IDictionary<string, object>>;
 
-                if (andSubChildren == null) continue; ;
+                if (andSubChildren == null) continue;
+
+                // If both conditions are off the same property, don't combine them
+                var keys = andSubChildren.SelectMany(list => list.Select(kvp => kvp.Key)).ToArray();
+                if (keys.Length != keys.Distinct().Count())
+                {
+                    continue;
+                }
 
                 nodeDictioray.Remove(andChild);
                 foreach (var andSubChild in andSubChildren)

--- a/src/CouchDB.Client/Query/Selector/SelectorObjectBuilder.cs
+++ b/src/CouchDB.Client/Query/Selector/SelectorObjectBuilder.cs
@@ -20,7 +20,7 @@ namespace CouchDB.Client.Query.Selector
 
         private static ExpandoObject OptimizeAndOperators(ExpandoObject node)
         {
-            var nodeDictioray = (IDictionary<string, object>) node;
+            var nodeDictioray = (IDictionary<string, object>)node;
             var andChildren = nodeDictioray.Where(n => n.Key == "$and").ToList();
             if (!andChildren.Any())
                 return (ExpandoObject)nodeDictioray;
@@ -29,7 +29,7 @@ namespace CouchDB.Client.Query.Selector
             {
                 var andSubChildren = andChild.Value as IEnumerable<IDictionary<string, object>>;
 
-                if(andSubChildren == null) continue;;
+                if (andSubChildren == null) continue; ;
 
                 nodeDictioray.Remove(andChild);
                 foreach (var andSubChild in andSubChildren)
@@ -38,7 +38,7 @@ namespace CouchDB.Client.Query.Selector
                 }
             }
 
-            return (ExpandoObject) nodeDictioray;
+            return (ExpandoObject)nodeDictioray;
         }
 
         private static ExpandoObject BuildObjectNode(ICouchNode node)
@@ -46,60 +46,60 @@ namespace CouchDB.Client.Query.Selector
             switch (node)
             {
                 case ConditionNode conditionNode:
-                {
-                    if (conditionNode.Type == ConditionNodeType.Equal)
                     {
-                        var condition = new ExpandoObject();
-                        condition.AddProperty(conditionNode.PropertyNode.Name, conditionNode.ValueNode.Value);
-                        return condition;
+                        if (conditionNode.Type == ConditionNodeType.Equal)
+                        {
+                            var condition = new ExpandoObject();
+                            condition.AddProperty(conditionNode.PropertyNode.Name, conditionNode.ValueNode.Value);
+                            return condition;
+                        }
+
+                        var symbol = GetConditionSymbol(conditionNode);
+
+                        var rightConditionObject = new ExpandoObject();
+                        rightConditionObject.AddProperty(symbol, conditionNode.ValueNode.Value);
+
+                        var conditionObject = new ExpandoObject();
+                        conditionObject.AddProperty(conditionNode.PropertyNode.Name, rightConditionObject);
+
+                        return conditionObject;
                     }
-
-                    var symbol = GetConditionSymbol(conditionNode);
-
-                    var rightConditionObject = new ExpandoObject();
-                    rightConditionObject.AddProperty(symbol, conditionNode.ValueNode.Value);
-
-                    var conditionObject = new ExpandoObject();
-                    conditionObject.AddProperty(conditionNode.PropertyNode.Name, rightConditionObject);
-
-                    return conditionObject;
-                }
                 case UnitaryNode unitaryNode:
-                {
-                    var childObject = BuildObjectNode(unitaryNode.Child);
+                    {
+                        var childObject = BuildObjectNode(unitaryNode.Child);
 
-                    var symbol = GetUnitarySymbol(unitaryNode.Type);
+                        var symbol = GetUnitarySymbol(unitaryNode.Type);
 
-                    var unitaryObject = new ExpandoObject();
-                    unitaryObject.AddProperty(symbol, childObject);
+                        var unitaryObject = new ExpandoObject();
+                        unitaryObject.AddProperty(symbol, childObject);
 
-                    return unitaryObject;
-                }
+                        return unitaryObject;
+                    }
                 case CombinationNode combinationNode:
-                {
-                    var symbol = GetCombinationSymbol(combinationNode.Type);
+                    {
+                        var symbol = GetCombinationSymbol(combinationNode.Type);
 
-                    var childrenObjects = combinationNode.Children.Select(c => BuildObjectNode(c)).ToList();
+                        var childrenObjects = combinationNode.Children.Select(c => BuildObjectNode(c)).ToList();
 
-                    var combinationObject = new ExpandoObject();
-                    combinationObject.AddProperty(symbol, childrenObjects);
+                        var combinationObject = new ExpandoObject();
+                        combinationObject.AddProperty(symbol, childrenObjects);
 
-                    return combinationObject;
-                }
+                        return combinationObject;
+                    }
                 case ArrayMatchNode arrayMatchNode:
-                {
-                    var symbol = GetArrayMatchSymbol(arrayMatchNode.Type);
+                    {
+                        var symbol = GetArrayMatchSymbol(arrayMatchNode.Type);
 
-                    var arraySelectorNode = BuildObjectNode(arrayMatchNode.ArraySelectorNode);
+                        var arraySelectorNode = BuildObjectNode(arrayMatchNode.ArraySelectorNode);
 
-                    var arraySelectorObject = new ExpandoObject();
-                    arraySelectorObject.AddProperty(symbol, arraySelectorNode);
+                        var arraySelectorObject = new ExpandoObject();
+                        arraySelectorObject.AddProperty(symbol, arraySelectorNode);
 
-                    var arrayMatchObject = new ExpandoObject();
-                    arrayMatchObject.AddProperty(arrayMatchNode.PropertyNode.Name, arraySelectorObject);
+                        var arrayMatchObject = new ExpandoObject();
+                        arrayMatchObject.AddProperty(arrayMatchNode.PropertyNode.Name, arraySelectorObject);
 
-                    return arrayMatchObject;
-                }
+                        return arrayMatchObject;
+                    }
             }
             throw new InvalidOperationException();
         }

--- a/src/CouchDB.sln
+++ b/src/CouchDB.sln
@@ -10,6 +10,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SolutionItems", "SolutionIt
 		..\README.md = ..\README.md
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CouchDB.Client.Tests", "CouchDB.Client.Tests\CouchDB.Client.Tests.csproj", "{D27ADAE7-B22F-4FAF-A042-6437820DB252}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -20,6 +22,10 @@ Global
 		{B3700668-9B25-4351-BEBC-2058711E2648}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B3700668-9B25-4351-BEBC-2058711E2648}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B3700668-9B25-4351-BEBC-2058711E2648}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D27ADAE7-B22F-4FAF-A042-6437820DB252}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D27ADAE7-B22F-4FAF-A042-6437820DB252}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D27ADAE7-B22F-4FAF-A042-6437820DB252}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D27ADAE7-B22F-4FAF-A042-6437820DB252}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
I ran into some bugs trying to use expressions to generate selectors.

A couple failure cases that I needed:
```
const int one = 1;
Expression<Func<MyDocument, bool>> query = t => t.MyInt == one;
```
```
var comparisonDoc = new MyDocument { MyInt = 1 };
Expression<Func<MyDocument, bool>> query = t => t.MyInt >= comparisonDoc.MyInt;
```

I was a little worried about breaking other functionality, so I wrote some unit tests to cover others too. I'm good with my implementation getting blown away by the queryable branch you're working on, but I think it's important that these use cases still work and are tested.