### PR TITLE
Prevent async deadlocks

### DIFF
--- a/src/CouchDB.Driver/CouchDB.Driver.csproj
+++ b/src/CouchDB.Driver/CouchDB.Driver.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Flurl.Http" Version="2.4.1" />
     <PackageReference Include="Humanizer.Core" Version="2.6.2" />
+    <PackageReference Include="Nito.AsyncEx.Context" Version="1.1.0" />
   </ItemGroup>
 
 </Project>

--- a/src/CouchDB.Driver/Helpers/RequestsHelper.cs
+++ b/src/CouchDB.Driver/Helpers/RequestsHelper.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using CouchDB.Driver.Exceptions;
 using CouchDB.Driver.Types;
 using Flurl.Http;
+using Nito.AsyncEx;
 
 namespace CouchDB.Driver.Helpers
 {
@@ -11,7 +12,7 @@ namespace CouchDB.Driver.Helpers
     {
         public static T SendRequest<T>(this Task<T> asyncRequest)
         {
-            return asyncRequest.SendRequestAsync().Result;
+            return AsyncContext.Run(() => asyncRequest.SendRequestAsync());
         }
         public static async Task<T> SendRequestAsync<T>(this Task<T> asyncRequest)
         {


### PR DESCRIPTION
I was getting deadlocks from the `.Result`. https://stackoverflow.com/a/9343733/1130636