### PR TITLE
Allow more types for .In() and .Contains()

### DIFF
--- a/src/CouchDB.Driver/Extensions/EnumerableExtensions.cs
+++ b/src/CouchDB.Driver/Extensions/EnumerableExtensions.cs
@@ -13,7 +13,7 @@ namespace CouchDB.Driver.Extensions
         /// <param name="source">A sequence in which to locate a value.</param>
         /// <param name="input">Values to locate in the sequence.</param>
         /// <returns>true if the source sequence contains all elements that has specified values; otherwise, false.</returns>
-        public static bool Contains<T>(this IEnumerable<T> source, IEnumerable<T> input) where T : IConvertible
+        public static bool Contains<T>(this IEnumerable<T> source, IEnumerable<T> input)
         {
             if (source == null)
             {

--- a/src/CouchDB.Driver/Extensions/ObjectExtensions.cs
+++ b/src/CouchDB.Driver/Extensions/ObjectExtensions.cs
@@ -15,7 +15,7 @@ namespace CouchDB.Driver.Extensions
         /// <param name="value">The value to locate in the input.</param>
         /// <param name="input">A sequence in which to locate the value.</param>
         /// <returns>true if the input sequence contains an element that has the specified value; otherwise, false.</returns>
-        public static bool In<T>(this T value, IEnumerable<T> input) where T : IConvertible
+        public static bool In<T>(this T value, IEnumerable<T> input)
         {
             if (value == null)
             {

--- a/tests/CouchDB.Driver.UnitTests/Find/Find_Selector_Conditions.cs
+++ b/tests/CouchDB.Driver.UnitTests/Find/Find_Selector_Conditions.cs
@@ -1,6 +1,7 @@
 using CouchDB.Driver.Extensions;
 using CouchDB.Driver.Types;
 using CouchDB.Driver.UnitTests.Models;
+using System;
 using Xunit;
 
 namespace CouchDB.Driver.UnitTests.Find
@@ -80,6 +81,13 @@ namespace CouchDB.Driver.UnitTests.Find
         {
             var json = _rebels.Where(r => r.Age.In(new[] { 20, 30 })).ToString();
             Assert.Equal(@"{""selector"":{""age"":{""$in"":[20,30]}}}", json);
+        }
+
+        [Fact]
+        public void Array_In_Guid()
+        {
+            var json = _rebels.Where(r => r.Guid.In(new[] { Guid.Parse("00000000-0000-0000-0000-000000000000"), Guid.Parse("11111111-1111-1111-1111-111111111111") })).ToString();
+            Assert.Equal(@"{""selector"":{""guid"":{""$in"":[""00000000-0000-0000-0000-000000000000"",""11111111-1111-1111-1111-111111111111""]}}}", json);
         }
         [Fact]
         public void Array_NotIn()


### PR DESCRIPTION
I needed `.In()` with a Guid, but Guid doesn't doesn't implement `IConvertible`. I couldn't find anything actually using IConvertible, so I just removed the constraint