### PR TITLE
Support querying with single item array

### DIFF
--- a/src/CouchDB.Driver/Translators/ConstantExpressionTranslator.cs
+++ b/src/CouchDB.Driver/Translators/ConstantExpressionTranslator.cs
@@ -84,20 +84,9 @@ namespace CouchDB.Driver
 
         private void VisitIEnumerable<T>(IList<T> list)
         {
-            if (list.Count < 1)
-            {
-                return;
-            }
-            if (list.Count == 1)
-            {
-                _sb.Append(VisitConst(list[0]));
-            }
-            else
-            {
-                _sb.Append("[");
-                _sb.Append(string.Join(",", list.Select(e => VisitConst(e))));
-                _sb.Append("]");
-            }
+            _sb.Append("[");
+            _sb.Append(string.Join(",", list.Select(e => VisitConst(e))));
+            _sb.Append("]");
 
             string VisitConst(object o)
             {

--- a/src/CouchDB.Driver/Translators/ConstantExpressionTranslator.cs
+++ b/src/CouchDB.Driver/Translators/ConstantExpressionTranslator.cs
@@ -1,5 +1,6 @@
 ﻿using Newtonsoft.Json;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -7,102 +8,76 @@ using System.Linq.Expressions;
 
 namespace CouchDB.Driver
 {
-#pragma warning disable IDE0058 // Expression value is never used
     internal partial class QueryTranslator
     {
         protected override Expression VisitConstant(ConstantExpression c)
         {
-            if (c.Value is IQueryable)
+            HandleConstant(c.Value);
+
+            return c;
+        }
+
+        private void HandleConstant(object constant)
+        {
+            if (constant is IQueryable)
             {
                 // assume constant nodes w/ IQueryables are table references
                 // q.ElementType.Name
             }
-            else if (c.Value == null)
+            else if (constant == null)
             {
                 _sb.Append("null");
             }
             else
             {
-                switch (Type.GetTypeCode(c.Value.GetType()))
+                switch (Type.GetTypeCode(constant.GetType()))
                 {
                     case TypeCode.Boolean:
-                        _sb.Append(((bool)c.Value) ? "true" : "false");
+                        _sb.Append(((bool)constant) ? "true" : "false");
                         break;
                     case TypeCode.String:
-                        _sb.Append($"\"{c.Value}\"");
+                        _sb.Append($"\"{constant}\"");
                         break;
                     case TypeCode.DateTime:
-                        _sb.Append(JsonConvert.SerializeObject(c.Value));
+                        _sb.Append(JsonConvert.SerializeObject(constant));
                         break;
                     case TypeCode.Object:
-                        if (c.Value is IList<bool>)
+                        if (constant is IEnumerable enumerable)
                         {
-                            VisitIEnumerable(c.Value as IList<bool>);
+                            VisitIEnumerable(enumerable);
                         }
-                        else if (c.Value is IList<int>)
+                        else if (constant is Guid)
                         {
-                            VisitIEnumerable(c.Value as IList<int>);
-                        }
-                        else if (c.Value is IList<long>)
-                        {
-                            VisitIEnumerable(c.Value as IList<long>);
-                        }
-                        else if (c.Value is IList<decimal>)
-                        {
-                            VisitIEnumerable(c.Value as IList<decimal>);
-                        }
-                        else if (c.Value is IList<float>)
-                        {
-                            VisitIEnumerable(c.Value as IList<float>);
-                        }
-                        else if (c.Value is IList<double>)
-                        {
-                            VisitIEnumerable(c.Value as IList<double>);
-                        }
-                        else if (c.Value is IList<string>)
-                        {
-                            VisitIEnumerable(c.Value as IList<string>);
-                        }
-                        else if (c.Value is Guid)
-                        {
-                            _sb.Append(JsonConvert.SerializeObject(c.Value));
+                            _sb.Append(JsonConvert.SerializeObject(constant));
                         }
                         else
                         {
-                            Debug.WriteLine($"The constant for '{c.Value}' not ufficially supported.");
-                            _sb.Append(JsonConvert.SerializeObject(c.Value));
+                            Debug.WriteLine($"The constant for '{constant}' not ufficially supported.");
+                            _sb.Append(JsonConvert.SerializeObject(constant));
                         }
                         break;
                     default:
-                        _sb.Append(c.Value);
+                        _sb.Append(constant);
                         break;
                 }
             }
 
-            return c;
         }
 
-        private void VisitIEnumerable<T>(IList<T> list)
+        private void VisitIEnumerable(IEnumerable list)
         {
             _sb.Append("[");
-            _sb.Append(string.Join(",", list.Select(e => VisitConst(e))));
-            _sb.Append("]");
-
-            string VisitConst(object o)
+            bool needsComma = false;
+            foreach (var item in list)
             {
-                switch (Type.GetTypeCode(o.GetType()))
+                if (needsComma)
                 {
-                    case TypeCode.Boolean:
-                        return (bool)o ? "true" : "false";
-                    case TypeCode.String:
-                        return $"\"{o}\"";
-                    case TypeCode.Object:
-                        throw new NotSupportedException($"The constant for '{o}' is not supported");
-                    default:
-                        return o.ToString();
+                    _sb.Append(",");
                 }
+                HandleConstant(item);
+                needsComma = true;
             }
+            _sb.Append("]");
         }
     }
-#pragma warning restore IDE0058 // Expression value is never used
 }

--- a/src/CouchDB.Driver/Translators/MethodCallExpressionTranslator.cs
+++ b/src/CouchDB.Driver/Translators/MethodCallExpressionTranslator.cs
@@ -1,6 +1,8 @@
 ﻿using CouchDB.Driver.Extensions;
 using CouchDB.Driver.Types;
+using Newtonsoft.Json;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 
@@ -315,7 +317,29 @@ namespace CouchDB.Driver
         {
             Visit(m.Arguments[0]);
             _sb.Append("\"use_index\":");
-            Visit(m.Arguments[1]);
+            if (!(m.Arguments[1] is ConstantExpression indexArgsExpression))
+            {
+                throw new ArgumentException("UseIndex requires an IList<string> argument");
+            }
+
+            if (!(indexArgsExpression.Value is IList<string> indexArgs))
+            {
+                throw new ArgumentException("UseIndex requires an IList<string> argument");
+            }
+            else if (indexArgs.Count == 1)
+            {
+                // use_index expects the value with [ or ] when it's a single item array
+                Visit(Expression.Constant(indexArgs[0]));
+            }
+            else if (indexArgs.Count == 2)
+            {
+                Visit(indexArgsExpression);
+            }
+            else
+            {
+                throw new ArgumentException("UseIndex requires 1 or 2 strings");
+            }
+
             _sb.Append(",");
             return m;
         }

--- a/tests/CouchDB.Driver.UnitTests/Find/Find_Selector_Conditions.cs
+++ b/tests/CouchDB.Driver.UnitTests/Find/Find_Selector_Conditions.cs
@@ -82,6 +82,12 @@ namespace CouchDB.Driver.UnitTests.Find
             Assert.Equal(@"{""selector"":{""age"":{""$in"":[20,30]}}}", json);
         }
         [Fact]
+        public void Array_InSingleItem()
+        {
+            var json = _rebels.Where(r => r.Age.In(new[] { 20 })).ToString();
+            Assert.Equal(@"{""selector"":{""age"":{""$in"":[20]}}}", json);
+        }
+        [Fact]
         public void Array_NotIn()
         {
             var json = _rebels.Where(r => !r.Age.In(new[] { 20, 30 })).ToString();


### PR DESCRIPTION
`_rebels.Where(r => r.Age.In(new[] { 20 }))` was querying with `{"age":{"$in":20}}}`, which CouchDb doesn't like. It looks like the special handling of 1 item arrays was in there for `UseIndex()`, so I moved that special case handling to UseIndex and let the rest of arrays include square brackets.

The last commit removes the 2nd constant handler and shares the 1st to reduce duplication. The change isn't strictly necessary, but I think it increases maintainability. If there's a side effect I'm not aware of, I'm happy to revert that