### PR TITLE
Bool without equals

### DIFF
--- a/src/CouchDB.Driver/Translators/BinaryExpressionTranslator.cs
+++ b/src/CouchDB.Driver/Translators/BinaryExpressionTranslator.cs
@@ -80,9 +80,9 @@ namespace CouchDB.Driver
                     return;
                 }
 
-                Visit(e.Left);
+                ForceToBinaryExpressionAndVisit(e.Left);
                 _sb.Append(",");
-                Visit(e.Right);
+                ForceToBinaryExpressionAndVisit(e.Right);
             }
 
             switch (b.NodeType)
@@ -106,6 +106,15 @@ namespace CouchDB.Driver
 
             InspectBinaryChildren(b, b.NodeType);
             _sb.Append("]");
+        }
+
+        private void ForceToBinaryExpressionAndVisit(Expression expression)
+        {
+            if (expression is MemberExpression)
+            {
+                expression = Expression.MakeBinary(ExpressionType.Equal, expression, Expression.Constant(true));
+            }
+            Visit(expression);
         }
 
         private void VisitBinaryConditionOperator(BinaryExpression b)

--- a/src/CouchDB.Driver/Translators/MethodCallExpressionTranslator.cs
+++ b/src/CouchDB.Driver/Translators/MethodCallExpressionTranslator.cs
@@ -140,7 +140,7 @@ namespace CouchDB.Driver
             Visit(m.Arguments[0]);
             _sb.Append("\"selector\":");
             var lambda = (LambdaExpression)StripQuotes(m.Arguments[1]);
-            Visit(lambda.Body);
+            ForceToBinaryExpressionAndVisit(lambda.Body);
             _sb.Append(",");
             _isSelectorSet = true;
             return m;

--- a/tests/CouchDB.Driver.UnitTests/Find/Find_Selector.cs
+++ b/tests/CouchDB.Driver.UnitTests/Find/Find_Selector.cs
@@ -45,6 +45,12 @@ namespace CouchDB.Driver.UnitTests.Find
             Assert.Equal(@"{""selector"":{""isJedi"":true}}", json);
         }
         [Fact]
+        public void Variable_NotBool()
+        {
+            var json = rebels.Where(r => !r.IsJedi).ToString();
+            Assert.Equal(@"{""selector"":{""isJedi"":false}}", json);
+        }
+        [Fact]
         public void Variable_Object()
         {
             var luke = new Rebel { Age = 19 };

--- a/tests/CouchDB.Driver.UnitTests/Find/Find_Selector.cs
+++ b/tests/CouchDB.Driver.UnitTests/Find/Find_Selector.cs
@@ -26,9 +26,10 @@ namespace CouchDB.Driver.UnitTests.Find
         {
             var json = rebels.Where(r =>
             r.Age == 19 &&
+            r.IsJedi &&
             (r.Name == "Luke" || r.Name == "Leia") &&
             r.Skills.Contains("force")).ToString();
-            Assert.Equal(@"{""selector"":{""$and"":[{""age"":19},{""$or"":[{""name"":""Luke""},{""name"":""Leia""}]},{""skills"":{""$all"":[""force""]}}]}}", json);
+            Assert.Equal(@"{""selector"":{""$and"":[{""age"":19},{""isJedi"":true},{""$or"":[{""name"":""Luke""},{""name"":""Leia""}]},{""skills"":{""$all"":[""force""]}}]}}", json);
         }
         [Fact]
         public void Variable_Const()
@@ -36,6 +37,12 @@ namespace CouchDB.Driver.UnitTests.Find
             var age = 19;
             var json = rebels.Where(r => r.Age == age).ToString();
             Assert.Equal(@"{""selector"":{""age"":19}}", json);
+        }
+        [Fact]
+        public void Variable_Bool()
+        {
+            var json = rebels.Where(r => r.IsJedi).ToString();
+            Assert.Equal(@"{""selector"":{""isJedi"":true}}", json);
         }
         [Fact]
         public void Variable_Object()

--- a/tests/CouchDB.Driver.UnitTests/_Models/Rebel.cs
+++ b/tests/CouchDB.Driver.UnitTests/_Models/Rebel.cs
@@ -10,6 +10,7 @@ namespace CouchDB.Driver.UnitTests.Models
         public string Name { get; set; }
         public string Surname { get; set; }
         public int Age { get; set; }
+        public bool IsJedi { get; set; }
         public Species Species { get; set; }
         public Guid Guid { get; set; }
         public List<string> Skills { get; set; }


### PR DESCRIPTION
`rebels.Where(r => r.IsJedi)` should be equivalent to `rebels.Where(r => r.IsJedi == true)`, but was creating an invalid CouchDb query `{"selector":"isJedi"}`.

I handled it by explicitly hooking into `.Where()` as well as the `&&` and `||` handlers. I can't think of anywhere else it's needed, but they may be some. There may be a better solution to doing this more universally too. I'm open to better solutions