### PR TITLE
Implicit bools in nested methods

### DIFF
--- a/tests/CouchDB.Driver.E2ETests/Client_Tests.cs
+++ b/tests/CouchDB.Driver.E2ETests/Client_Tests.cs
@@ -8,6 +8,7 @@ using Xunit;
 
 namespace CouchDB.Driver.E2E
 {
+    [Trait("Category", "Integration")]
     public class ClientTests
     {
         [Fact]
@@ -54,10 +55,10 @@ namespace CouchDB.Driver.E2E
                 {
                     users = await client.CreateDatabaseAsync<CouchUser>().ConfigureAwait(false);
                 }
-                
+
                 var luke = await users.CreateAsync(new CouchUser(name: "luke", password: "lasersword")).ConfigureAwait(false);
                 Assert.Equal("luke", luke.Name);
-                
+
                 luke = await users.FindAsync(luke.Id).ConfigureAwait(false);
                 Assert.Equal("luke", luke.Name);
 

--- a/tests/CouchDB.Driver.UnitTests/Find/Find_Selector_Combinations.cs
+++ b/tests/CouchDB.Driver.UnitTests/Find/Find_Selector_Combinations.cs
@@ -59,10 +59,40 @@ namespace CouchDB.Driver.UnitTests.Find
             Assert.Equal(@"{""selector"":{""battles"":{""$elemMatch"":{""planet"":""Naboo""}}}}", json);
         }
         [Fact]
+        public void ElemMatchImplicitBool()
+        {
+            var json = _rebels.Where(r => r.Battles.Any(b => b.DidWin)).ToString();
+            Assert.Equal(@"{""selector"":{""battles"":{""$elemMatch"":{""didWin"":true}}}}", json);
+        }
+        [Fact]
+        public void ElemMatchBoolExplicit()
+        {
+            var json = _rebels.Where(r => r.Battles.Any(b => b.DidWin == true)).ToString();
+            Assert.Equal(@"{""selector"":{""battles"":{""$elemMatch"":{""didWin"":true}}}}", json);
+        }
+        [Fact]
+        public void ElemMatchNested()
+        {
+            var json = _rebels.Where(r => r.Battles.Any(b => b.Vehicles.Any(v => v.CanFly == true))).ToString();
+            Assert.Equal(@"{""selector"":{""battles"":{""$elemMatch"":{""vehicles"":{""$elemMatch"":{""canFly"":true}}}}}}", json);
+        }
+        [Fact]
+        public void ElemMatchNestedImplicitBool()
+        {
+            var json = _rebels.Where(r => r.Battles.Any(b => b.Vehicles.Any(v => v.CanFly))).ToString();
+            Assert.Equal(@"{""selector"":{""battles"":{""$elemMatch"":{""vehicles"":{""$elemMatch"":{""canFly"":true}}}}}}", json);
+        }
+        [Fact]
         public void AllMatch()
         {
             var json = _rebels.Where(r => r.Battles.All(b => b.Planet == "Naboo")).ToString();
             Assert.Equal(@"{""selector"":{""battles"":{""$allMatch"":{""planet"":""Naboo""}}}}", json);
+        }
+        [Fact]
+        public void AllMatchImplicitBool()
+        {
+            var json = _rebels.Where(r => r.Battles.All(b => b.DidWin)).ToString();
+            Assert.Equal(@"{""selector"":{""battles"":{""$allMatch"":{""didWin"":true}}}}", json);
         }
     }
 }

--- a/tests/CouchDB.Driver.UnitTests/_Models/Battle.cs
+++ b/tests/CouchDB.Driver.UnitTests/_Models/Battle.cs
@@ -6,7 +6,9 @@ namespace CouchDB.Driver.UnitTests.Models
 {
     public class Battle
     {
+        public bool DidWin { get; set; }
         public string Planet { get; set; }
         public DateTime Date { get; set; }
+        public List<Vehicle> Vehicles { get; set; } = new List<Vehicle>();
     }
 }

--- a/tests/CouchDB.Driver.UnitTests/_Models/Vehicle.cs
+++ b/tests/CouchDB.Driver.UnitTests/_Models/Vehicle.cs
@@ -1,0 +1,7 @@
+﻿namespace CouchDB.Driver.UnitTests.Models
+{
+    public class Vehicle
+    {
+        public bool CanFly { get; set; }
+    }
+}


### PR DESCRIPTION
`_rebels.Where(r => r.Battles.Any(b => b.DidWin))` was querying with `{"selector":{"battles":{"$elemMatch":"didWin"}}}` instead of `{"selector":{"battles":{"$elemMatch":{"didWin":true}}}}`. To fix, I changed it so the `BoolMemberToConstantEvaluator` processes all children of a `.Where()` instead of resetting at the next method call