### PR TITLE
Finalizer deadlock

### DIFF
--- a/src/CouchDB.Driver/CouchClient.cs
+++ b/src/CouchDB.Driver/CouchClient.cs
@@ -303,7 +303,10 @@ namespace CouchDB.Driver
 
         protected virtual void Dispose(bool disposing)
         {
-            AsyncContext.Run(() => LogoutAsync().ConfigureAwait(false));
+            if (_settings.LogOutOnDispose)
+            {
+                AsyncContext.Run(() => LogoutAsync().ConfigureAwait(false));
+            }
             _flurlClient.Dispose();
         }
 

--- a/src/CouchDB.Driver/CouchClient.cs
+++ b/src/CouchDB.Driver/CouchClient.cs
@@ -303,7 +303,7 @@ namespace CouchDB.Driver
 
         protected virtual void Dispose(bool disposing)
         {
-            AsyncContext.Run(() => LogoutAsync());
+            AsyncContext.Run(() => LogoutAsync().ConfigureAwait(false));
             _flurlClient.Dispose();
         }
 

--- a/src/CouchDB.Driver/CouchClient.cs
+++ b/src/CouchDB.Driver/CouchClient.cs
@@ -303,7 +303,7 @@ namespace CouchDB.Driver
 
         protected virtual void Dispose(bool disposing)
         {
-            if (_settings.LogOutOnDispose)
+            if (_settings.AuthenticationType == AuthenticationType.Cookie && _settings.LogOutOnDispose)
             {
                 AsyncContext.Run(() => LogoutAsync().ConfigureAwait(false));
             }

--- a/src/CouchDB.Driver/Settings/CouchSettings.cs
+++ b/src/CouchDB.Driver/Settings/CouchSettings.cs
@@ -23,6 +23,7 @@ namespace CouchDB.Driver.Settings
         internal DocumentCaseType DocumentsCaseType { get; private set; }
         internal PropertyCaseType PropertiesCase { get; private set; }
         internal bool CheckDatabaseExists { get; private set; }
+        internal bool LogOutOnDispose { get; private set; }
         internal Func<HttpRequestMessage, X509Certificate2, X509Chain, SslPolicyErrors, bool> ServerCertificateCustomValidationCallback { get; private set; }
 
         internal CouchSettings()
@@ -31,6 +32,7 @@ namespace CouchDB.Driver.Settings
             PluralizeEntitis = true;
             DocumentsCaseType = DocumentCaseType.UnderscoreCase;
             PropertiesCase = PropertyCaseType.CamelCase;
+            LogOutOnDispose = true;
         }
 
         /// <summary>
@@ -142,6 +144,12 @@ namespace CouchDB.Driver.Settings
         public CouchSettings EnsureDatabaseExists()
         {
             CheckDatabaseExists = true;
+            return this;
+        }
+
+        public CouchSettings DisableLogOutOnDispose()
+        {
+            LogOutOnDispose = false;
             return this;
         }
     }


### PR DESCRIPTION
I ran into a situation where the CouchClient finalizer was deadlocking a unit test if run from .NET Framework. It doesn't affect .NET Core because of changes to the async context in .NET Core.

I didn't commit my unit test because it didn't feel worth an extra project to have .NET Framework only tests, but here's the test in case you're interested. When run against .NET Framework, it shows success, but the test runner never completes.
```
[TestMethod]
public void FinalizerHangs()
{
    var client = new CouchClient("http://localhost");
}
```

I also limited when `Dispose()` calls `Logoff()`. It's not needed for Basic or Anonymous auth. I also added an opt-out setting for cookie auth.

If it's not too much trouble, I would appreciate if you kicked a build (even if it's just prerelease). Thanks!

