### PR TITLE
Exception handling

### DIFF
--- a/src/CouchDB.Driver/Exceptions/CouchConflictException.cs
+++ b/src/CouchDB.Driver/Exceptions/CouchConflictException.cs
@@ -1,16 +1,14 @@
-﻿namespace CouchDB.Driver.Exceptions
+﻿using CouchDB.Driver.DTOs;
+using System;
+
+namespace CouchDB.Driver.Exceptions
 {
     /// <summary>
     /// The exception that is thrown when there is a conflict.
     /// </summary>
     public class CouchConflictException : CouchException
     {
-        /// <summary>
-        /// Creates a new instance of CouchConflictException.
-        /// </summary>
-        /// <param name="message">Error message</param>
-        /// <param name="reason">Error reason</param>
-        public CouchConflictException(string message, string reason) : base(message, reason) { }
+        internal CouchConflictException(CouchError couchError, Exception innerException) : base(couchError, innerException) { }
 
         public CouchConflictException()
         {
@@ -20,7 +18,7 @@
         {
         }
 
-        public CouchConflictException(string message, System.Exception innerException) : base(message, innerException)
+        public CouchConflictException(string message, Exception innerException) : base(message, innerException)
         {
         }
     }

--- a/src/CouchDB.Driver/Exceptions/CouchException.cs
+++ b/src/CouchDB.Driver/Exceptions/CouchException.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using CouchDB.Driver.DTOs;
+using System;
 
 namespace CouchDB.Driver.Exceptions
 {
@@ -12,18 +13,31 @@ namespace CouchDB.Driver.Exceptions
         /// </summary>
         /// <param name="message">Error message</param>
         /// <param name="reason">Error reason</param>
-        public CouchException(string message, string reason) : base(message, new Exception(reason)) { }
-
-        public CouchException()
+        public CouchException(string message, string reason) : this(message, reason, null)
         {
         }
 
-        public CouchException(string message) : base(message)
+        public CouchException() : this(null, null, null)
         {
         }
 
-        public CouchException(string message, Exception innerException) : base(message, innerException)
+        public CouchException(string message) : this(message, null, null)
         {
         }
+
+        public CouchException(string message, Exception innerException) : this(message, null, innerException)
+        {
+        }
+
+        internal CouchException(CouchError couchError, Exception innerException) : this(couchError?.Error, couchError?.Reason, innerException)
+        {
+        }
+
+        public CouchException(string message, string reason, Exception innerException) : base(message, innerException)
+        {
+            Reason = reason;
+        }
+
+        public string Reason { get; }
     }
 }

--- a/src/CouchDB.Driver/Exceptions/CouchNoIndexException.cs
+++ b/src/CouchDB.Driver/Exceptions/CouchNoIndexException.cs
@@ -1,16 +1,14 @@
-﻿namespace CouchDB.Driver.Exceptions
+﻿using CouchDB.Driver.DTOs;
+using System;
+
+namespace CouchDB.Driver.Exceptions
 {
     /// <summary>
     /// The exception that is thrown when there is no index for the query.
     /// </summary>
     public class CouchNoIndexException : CouchException
     {
-        /// <summary>
-        /// Creates a new instance of CouchNoIndexException.
-        /// </summary>
-        /// <param name="message">Error message</param>
-        /// <param name="reason">Error reason</param>
-        public CouchNoIndexException(string message, string reason) : base(message, reason) { }
+        internal CouchNoIndexException(CouchError couchError, Exception innerException) : base(couchError, innerException) { }
 
         public CouchNoIndexException()
         {
@@ -20,7 +18,7 @@
         {
         }
 
-        public CouchNoIndexException(string message, System.Exception innerException) : base(message, innerException)
+        public CouchNoIndexException(string message, Exception innerException) : base(message, innerException)
         {
         }
     }

--- a/src/CouchDB.Driver/Exceptions/CouchNotFoundException.cs
+++ b/src/CouchDB.Driver/Exceptions/CouchNotFoundException.cs
@@ -1,16 +1,14 @@
-﻿namespace CouchDB.Driver.Exceptions
+﻿using CouchDB.Driver.DTOs;
+using System;
+
+namespace CouchDB.Driver.Exceptions
 {
     /// <summary>
     /// The exception that is thrown when something is not found.
     /// </summary>
     public class CouchNotFoundException : CouchException
     {
-        /// <summary>
-        /// Creates a new instance of CouchNotFoundException.
-        /// </summary>
-        /// <param name="message">Error message</param>
-        /// <param name="reason">Error reason</param>
-        public CouchNotFoundException(string message, string reason) : base(message, reason) { }
+        internal CouchNotFoundException(CouchError couchError, Exception innerException) : base(couchError, innerException) { }
 
         public CouchNotFoundException()
         {
@@ -20,7 +18,7 @@
         {
         }
 
-        public CouchNotFoundException(string message, System.Exception innerException) : base(message, innerException)
+        public CouchNotFoundException(string message, Exception innerException) : base(message, innerException)
         {
         }
     }

--- a/src/CouchDB.Driver/Helpers/RequestsHelper.cs
+++ b/src/CouchDB.Driver/Helpers/RequestsHelper.cs
@@ -43,12 +43,5 @@ namespace CouchDB.Driver.Helpers
                 }
             }
         }
-
-        private static Exception NewCouchExteption(this CouchError e, Type type)
-        {
-            ConstructorInfo ctor = type.GetConstructor(new[] { typeof(string), typeof(string) });
-            var exception = (CouchException)ctor.Invoke(new string[] { e.Error, e.Reason });
-            return exception;
-        }
     }
 }

--- a/src/CouchDB.Driver/Helpers/RequestsHelper.cs
+++ b/src/CouchDB.Driver/Helpers/RequestsHelper.cs
@@ -33,13 +33,13 @@ namespace CouchDB.Driver.Helpers
                 switch (ex.Call.HttpStatus)
                 {
                     case HttpStatusCode.Conflict:
-                        throw couchError.NewCouchExteption(typeof(CouchConflictException));
+                        throw new CouchConflictException(couchError, ex);
                     case HttpStatusCode.NotFound:
-                        throw couchError.NewCouchExteption(typeof(CouchNotFoundException));
+                        throw new CouchNotFoundException(couchError, ex);
                     case HttpStatusCode.BadRequest when couchError.Error == "no_usable_index":
-                        throw couchError.NewCouchExteption(typeof(CouchNoIndexException));
+                        throw new CouchNoIndexException(couchError, ex);
                     default:
-                        throw new CouchException(couchError.Error, couchError.Reason);
+                        throw new CouchException(couchError, ex);
                 }
             }
         }

--- a/tests/CouchDB.Driver.UnitTests/Client_Tests.cs
+++ b/tests/CouchDB.Driver.UnitTests/Client_Tests.cs
@@ -1,7 +1,10 @@
-﻿using CouchDB.Driver.Types;
+﻿using CouchDB.Driver.Exceptions;
+using CouchDB.Driver.Types;
 using CouchDB.Driver.UnitTests.Models;
 using Flurl.Http.Testing;
 using System.Collections.Generic;
+using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Xunit;
@@ -110,7 +113,7 @@ namespace CouchDB.Driver.UnitTests
 
                 using (var client = new CouchClient("http://localhost"))
                 {
-                    var result = await client.IsUpAsync();                    
+                    var result = await client.IsUpAsync();
                     Assert.True(result);
                 }
             }
@@ -127,7 +130,7 @@ namespace CouchDB.Driver.UnitTests
 
                 using (var client = new CouchClient("http://localhost"))
                 {
-                    httpTest.RespondWith("Not found",  404);
+                    httpTest.RespondWith("Not found", 404);
                     var result = await client.IsUpAsync();
                     Assert.False(result);
                 }
@@ -174,6 +177,84 @@ namespace CouchDB.Driver.UnitTests
             }
         }
 
+        #endregion
+
+        #region Error Handling
+        [Fact]
+        public async Task ConflictException()
+        {
+            using (var httpTest = new HttpTest())
+            {
+                httpTest.RespondWith(status: (int)HttpStatusCode.Conflict);
+
+                using (var client = new CouchClient("http://localhost"))
+                {
+                    await Assert.ThrowsAsync<CouchConflictException>(() => client.CreateDatabaseAsync<Rebel>());
+                }
+            }
+        }
+
+        [Fact]
+        public async Task NotFoundException()
+        {
+            using (var httpTest = new HttpTest())
+            {
+                httpTest.RespondWith(status: (int)HttpStatusCode.NotFound);
+
+                using (var client = new CouchClient("http://localhost"))
+                {
+                    await Assert.ThrowsAsync<CouchNotFoundException>(() => client.DeleteDatabaseAsync<Rebel>());
+                }
+            }
+        }
+
+        [Fact]
+        public void BadRequestException()
+        {
+            using (var httpTest = new HttpTest())
+            {
+                httpTest.RespondWith(@"{error: ""no_usable_index""}", (int)HttpStatusCode.BadRequest);
+
+                using (var client = new CouchClient("http://localhost"))
+                {
+                    var db = client.GetDatabase<Rebel>();
+                    Assert.Throws<CouchNoIndexException>(() => db.UseIndex("aoeu").ToList());
+                }
+            }
+        }
+
+        [Fact]
+        public async Task GenericExceptionWithMessage()
+        {
+            using (var httpTest = new HttpTest())
+            {
+                string message = "message text";
+                string reason = "reason text";
+                httpTest.RespondWith($"{{error: \"{message}\", reason: \"{reason}\"}}", (int)HttpStatusCode.InternalServerError);
+
+                using (var client = new CouchClient("http://localhost"))
+                {
+                    var db = client.GetDatabase<Rebel>();
+                    var couchException = await Assert.ThrowsAsync<CouchException>(() => db.FindAsync("aoeu"));
+                    Assert.Equal(message, couchException.Message);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task GenericExceptionNoMessage()
+        {
+            using (var httpTest = new HttpTest())
+            {
+                httpTest.RespondWith(status: (int)HttpStatusCode.InternalServerError);
+
+                using (var client = new CouchClient("http://localhost"))
+                {
+                    var db = client.GetDatabase<Rebel>();
+                    var couchException = await Assert.ThrowsAsync<CouchException>(() => db.FindAsync("aoeu"));
+                }
+            }
+        }
         #endregion
     }
 }

--- a/tests/CouchDB.Driver.UnitTests/Client_Tests.cs
+++ b/tests/CouchDB.Driver.UnitTests/Client_Tests.cs
@@ -189,7 +189,8 @@ namespace CouchDB.Driver.UnitTests
 
                 using (var client = new CouchClient("http://localhost"))
                 {
-                    await Assert.ThrowsAsync<CouchConflictException>(() => client.CreateDatabaseAsync<Rebel>());
+                    var couchException = await Assert.ThrowsAsync<CouchConflictException>(() => client.CreateDatabaseAsync<Rebel>());
+                    Assert.IsType<Flurl.Http.FlurlHttpException>(couchException.InnerException);
                 }
             }
         }
@@ -203,7 +204,8 @@ namespace CouchDB.Driver.UnitTests
 
                 using (var client = new CouchClient("http://localhost"))
                 {
-                    await Assert.ThrowsAsync<CouchNotFoundException>(() => client.DeleteDatabaseAsync<Rebel>());
+                    var couchException = await Assert.ThrowsAsync<CouchNotFoundException>(() => client.DeleteDatabaseAsync<Rebel>());
+                    Assert.IsType<Flurl.Http.FlurlHttpException>(couchException.InnerException);
                 }
             }
         }
@@ -218,7 +220,8 @@ namespace CouchDB.Driver.UnitTests
                 using (var client = new CouchClient("http://localhost"))
                 {
                     var db = client.GetDatabase<Rebel>();
-                    Assert.Throws<CouchNoIndexException>(() => db.UseIndex("aoeu").ToList());
+                    var couchException = Assert.Throws<CouchNoIndexException>(() => db.UseIndex("aoeu").ToList());
+                    Assert.IsType<Flurl.Http.FlurlHttpException>(couchException.InnerException);
                 }
             }
         }
@@ -237,6 +240,8 @@ namespace CouchDB.Driver.UnitTests
                     var db = client.GetDatabase<Rebel>();
                     var couchException = await Assert.ThrowsAsync<CouchException>(() => db.FindAsync("aoeu"));
                     Assert.Equal(message, couchException.Message);
+                    Assert.Equal(reason, couchException.Reason);
+                    Assert.IsType<Flurl.Http.FlurlHttpException>(couchException.InnerException);
                 }
             }
         }
@@ -252,6 +257,7 @@ namespace CouchDB.Driver.UnitTests
                 {
                     var db = client.GetDatabase<Rebel>();
                     var couchException = await Assert.ThrowsAsync<CouchException>(() => db.FindAsync("aoeu"));
+                    Assert.IsType<Flurl.Http.FlurlHttpException>(couchException.InnerException);
                 }
             }
         }


### PR DESCRIPTION
I was running into NullReferenceExceptions if there wasn't a message/reason returned for an error. I started looking at exception handling with an eye on diagnosing from the outside and think these changes should help.

- We were null checking for known exception types, but unknown ones were assuming a message would be available. This would lead to `NullReferenceException` for lots of unhappy paths like when the db server is offline
- While testing, I noticed that `CouchNoIndexException` was being wrapped inside a `TargetInvocationException`. I unwrapped that so it's easier to catch
- It was bothering me that the underlying http exceptions couldn't be seen in the exception info, so I added the `FlurlHttpException` as the `InnerException` and moved `Reason` to it's own property