### PR TITLE
$in queries with enums serialized as ints

### DIFF
--- a/src/CouchDB.Driver/Translators/ConstantExpressionTranslator.cs
+++ b/src/CouchDB.Driver/Translators/ConstantExpressionTranslator.cs
@@ -56,6 +56,9 @@ namespace CouchDB.Driver
                             _sb.Append(JsonConvert.SerializeObject(constant));
                         }
                         break;
+                    case TypeCode.Int32:
+                        _sb.Append((int)constant);
+                        break;
                     default:
                         _sb.Append(constant);
                         break;

--- a/tests/CouchDB.Driver.UnitTests/Find/Find_Selector_Conditions.cs
+++ b/tests/CouchDB.Driver.UnitTests/Find/Find_Selector_Conditions.cs
@@ -96,6 +96,12 @@ namespace CouchDB.Driver.UnitTests.Find
             Assert.Equal(@"{""selector"":{""age"":{""$in"":[20]}}}", json);
         }
         [Fact]
+        public void Array_InEnum()
+        {
+            var json = _rebels.Where(r => r.Species.In(new[] { Species.Human, Species.Droid })).ToString();
+            Assert.Equal(@"{""selector"":{""species"":{""$in"":[0,1]}}}", json);
+        }
+        [Fact]
         public void Array_NotIn()
         {
             var json = _rebels.Where(r => !r.Age.In(new[] { 20, 30 })).ToString();


### PR DESCRIPTION
Closes #47 
Enums in arrays were being serialized by their name (`{"selector":{"species":{"$in":[Human,Droid]}}}`), which wasn't consistent with other places enums were serialized for queries (`{"selector":{"species":{"$in":[0,1]}}}`). This changes it to serialize as an int