### PR TITLE
Json escape strings

### DIFF
--- a/src/CouchDB.Driver/Translators/ConstantExpressionTranslator.cs
+++ b/src/CouchDB.Driver/Translators/ConstantExpressionTranslator.cs
@@ -36,7 +36,7 @@ namespace CouchDB.Driver
                         _sb.Append(((bool)constant) ? "true" : "false");
                         break;
                     case TypeCode.String:
-                        _sb.Append($"\"{constant}\"");
+                        _sb.Append(JsonConvert.SerializeObject(constant));
                         break;
                     case TypeCode.DateTime:
                         _sb.Append(JsonConvert.SerializeObject(constant));

--- a/tests/CouchDB.Driver.UnitTests/Find/Find_Selector.cs
+++ b/tests/CouchDB.Driver.UnitTests/Find/Find_Selector.cs
@@ -110,5 +110,11 @@ namespace CouchDB.Driver.UnitTests.Find
             var json = _rebels.Where(r => r.IsJedi != false).OrderBy(r => r.IsJedi).ToString();
             Assert.Equal(@"{""selector"":{""isJedi"":{""$ne"":false}},""sort"":[""isJedi""]}", json);
         }
+        [Fact]
+        public void Variable_String_IsJsonEscaped()
+        {
+            var json = _rebels.Where(r => r.Name == @"Chewbacca (""Chewie"")").ToString();
+            Assert.Equal(@"{""selector"":{""name"":""Chewbacca (\""Chewie\"")""}}", json);
+        }
     }
 }


### PR DESCRIPTION
I noticed that strings containing JSON special characters were breaking queries with a 400 bad request error. This fixes that by escaping the incoming string.

This is causing a bug I'm trying to fix in prod so an updated release this week would be appreciated.