### PR TITLE
fix FindManyAsync crash on non-existing documents

### DIFF
--- a/src/CouchDB.Driver/CouchDatabase.cs
+++ b/src/CouchDB.Driver/CouchDatabase.cs
@@ -225,7 +225,8 @@ namespace CouchDB.Driver
 
             foreach (TSource document in documents)
             {
-                InitAttachments(document);
+                if (document != null)
+                    InitAttachments(document);
             }
 
             return documents;


### PR DESCRIPTION
See #75