### PR TITLE
Make json NullValueHandling configurable

### DIFF
--- a/src/CouchDB.Driver/CouchClient.cs
+++ b/src/CouchDB.Driver/CouchClient.cs
@@ -90,7 +90,8 @@ namespace CouchDB.Driver
             {
                 s.JsonSerializer = new NewtonsoftJsonSerializer(new JsonSerializerSettings
                 {
-                    ContractResolver = new CouchContractResolver(_options.PropertiesCase)
+                    ContractResolver = new CouchContractResolver(_options.PropertiesCase),
+                    NullValueHandling = _options.NullValueHandling ?? NullValueHandling.Include
                 });
                 s.BeforeCallAsync = OnBeforeCallAsync;
                 if (_options.ServerCertificateCustomValidationCallback != null)

--- a/src/CouchDB.Driver/CouchDatabase.cs
+++ b/src/CouchDB.Driver/CouchDatabase.cs
@@ -11,13 +11,13 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Net;
 using System.Net.Http;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using CouchDB.Driver.ChangesFeed;
 using CouchDB.Driver.ChangesFeed.Responses;
+using CouchDB.Driver.Database;
 using CouchDB.Driver.Local;
 using CouchDB.Driver.Options;
 using CouchDB.Driver.Query;
@@ -45,6 +45,8 @@ namespace CouchDB.Driver
 
         /// <inheritdoc />
         public ILocalDocuments LocalDocuments { get; }
+        
+        public IIndexProvider<TSource> IndexProvider { get; } 
 
         internal CouchDatabase(IFlurlClient flurlClient, CouchOptions options, QueryContext queryContext)
         {
@@ -60,6 +62,7 @@ namespace CouchDB.Driver
 
             Security = new CouchSecurity(NewRequest);
             LocalDocuments = new LocalDocuments(flurlClient, queryContext);
+            IndexProvider = new IndexProvider<TSource>(this);
         }
 
         #region Find

--- a/src/CouchDB.Driver/Database/IIndexProvider.cs
+++ b/src/CouchDB.Driver/Database/IIndexProvider.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using CouchDB.Driver.Types;
+
+namespace CouchDB.Driver.Database
+{
+    public interface IIndexProvider<TSource> where TSource : CouchDocument
+    {
+        Task<bool> CreateAsync(Action<IndexInfo<TSource>> index, CancellationToken cancellationToken = default);
+        Task<bool> CreateOrUpdateAsync(Action<IndexInfo<TSource>> index, CancellationToken cancellationToken = default);
+    }
+}

--- a/src/CouchDB.Driver/Database/IndexDesignInfo.cs
+++ b/src/CouchDB.Driver/Database/IndexDesignInfo.cs
@@ -1,0 +1,11 @@
+﻿using Newtonsoft.Json;
+
+namespace CouchDB.Driver.Database
+{
+    public class IndexDesignInfo
+    {
+        [JsonProperty("ddoc")] public string? DDoc { get; set; }
+
+        [JsonProperty("Name")] public string? Name { get; set; }
+    }
+}

--- a/src/CouchDB.Driver/Database/IndexDesignResponse.cs
+++ b/src/CouchDB.Driver/Database/IndexDesignResponse.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace CouchDB.Driver.Database
+{
+    public class IndexDesignResponse
+    {
+        [JsonProperty("indexes")]
+#pragma warning disable 8618
+        public IEnumerable<IndexDesignInfo> Indexes { get; internal set; }
+#pragma warning restore 8618
+    }
+}

--- a/src/CouchDB.Driver/Database/IndexInfo.cs
+++ b/src/CouchDB.Driver/Database/IndexInfo.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Linq.Expressions;
+
+namespace CouchDB.Driver.Database
+{
+    public class IndexInfo<TSource> where TSource : class
+    {
+        public string? IndexName { get; set; }
+        public Expression<Func<TSource, object>>? Fields { get; set; }
+    }
+}

--- a/src/CouchDB.Driver/Database/IndexProvider.cs
+++ b/src/CouchDB.Driver/Database/IndexProvider.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Dynamic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
+using CouchDB.Driver.DTOs;
+using CouchDB.Driver.Helpers;
+using CouchDB.Driver.Types;
+using Flurl.Http;
+
+namespace CouchDB.Driver.Database
+{
+    public class IndexProvider<TSource> : IIndexProvider<TSource> where TSource : CouchDocument
+    {
+        private readonly ICouchDatabase<TSource> _database;
+
+        public IndexProvider(ICouchDatabase<TSource> database)
+        {
+            _database = database;
+        }
+
+        public async Task<bool> CreateAsync(Action<IndexInfo<TSource>> index,
+            CancellationToken cancellationToken = default)
+        {
+            object message = _createMessage(index);
+
+            IFlurlRequest request = _database.NewRequest();
+            IndexSaveResponse response = await request
+                .AppendPathSegment("_index")
+                .PostJsonAsync(message, cancellationToken)
+                .ReceiveJson<IndexSaveResponse>()
+                .SendRequestAsync()
+                .ConfigureAwait(false);
+
+            return "created" == response.Result;
+        }
+
+        public async Task<bool> CreateOrUpdateAsync(Action<IndexInfo<TSource>> index,
+            CancellationToken cancellationToken = default)
+        {
+            IFlurlRequest request = _database.NewRequest();
+            IndexDesignResponse response = await request
+                .AppendPathSegment("_index")
+                .GetJsonAsync<IndexDesignResponse>()
+                .SendRequestAsync()
+                .ConfigureAwait(false);
+
+            var message = _createMessage(index);
+            var currentIndex = response.Indexes.FirstOrDefault(x => x.Name == message.Name);
+            if (currentIndex != null)
+            {
+                await Delete(currentIndex.DDoc, currentIndex.Name, cancellationToken).ConfigureAwait(false);
+            }
+
+            return await CreateAsync(index, cancellationToken).ConfigureAwait(false);
+        }
+
+        private static IndexSaveRequest _createMessage(Action<IndexInfo<TSource>> index)
+        {
+            if (index == null)
+            {
+                throw new ArgumentNullException(nameof(index));
+            }
+
+            var info = new IndexInfo<TSource>();
+            index.Invoke(info);
+
+            Check.NotNull(info, nameof(info));
+            Check.NotNull(info.IndexName!, "index must be not null or empty");
+            Check.NotNull(info.Fields!, "fields must be not null or empty");
+
+
+            NewExpression? body = info?.Fields?.Body as NewExpression;
+            var fields = body?.Arguments.Select(x => (x as MemberExpression)?.Member.Name);
+            var message = new IndexSaveRequest
+            {
+                Name = info?.IndexName, Index = new IndexSaveRequestFields {Fields = fields}, Type = "json"
+            };
+            return message;
+        }
+
+        private async Task<bool> Delete(string? currentIndexDDoc, string? currentIndexName,
+            CancellationToken cancellationToken)
+        {
+            IFlurlRequest request = _database.NewRequest();
+            var response = await request
+                .AppendPathSegments("_index", currentIndexDDoc, "json", currentIndexName)
+                .DeleteAsync(cancellationToken)
+                .SendRequestAsync()
+                .ReceiveJson<OperationResult>()
+                .ConfigureAwait(false);
+
+            return response.Ok;
+        }
+    }
+}

--- a/src/CouchDB.Driver/Database/IndexSaveRequest.cs
+++ b/src/CouchDB.Driver/Database/IndexSaveRequest.cs
@@ -1,0 +1,9 @@
+﻿namespace CouchDB.Driver.Database
+{
+    internal class IndexSaveRequest
+    {
+        public string? Type { get; set; }
+        public string? Name { get; set; }
+        public IndexSaveRequestFields? Index { get; set; }
+    }
+}

--- a/src/CouchDB.Driver/Database/IndexSaveRequestFields.cs
+++ b/src/CouchDB.Driver/Database/IndexSaveRequestFields.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+
+namespace CouchDB.Driver.Database
+{
+    internal class IndexSaveRequestFields
+    {
+#pragma warning disable 8618
+        public IEnumerable<string?>? Fields { get; internal set; }
+#pragma warning restore 8618
+    }
+}

--- a/src/CouchDB.Driver/Database/IndexSaveResponse.cs
+++ b/src/CouchDB.Driver/Database/IndexSaveResponse.cs
@@ -1,0 +1,9 @@
+﻿using Newtonsoft.Json;
+
+namespace CouchDB.Driver.Database
+{
+    public class IndexSaveResponse
+    {
+        [JsonProperty("result")] public string? Result { get; set; }
+    }
+}

--- a/src/CouchDB.Driver/ICouchDatabase.cs
+++ b/src/CouchDB.Driver/ICouchDatabase.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using CouchDB.Driver.ChangesFeed;
 using CouchDB.Driver.ChangesFeed.Responses;
+using CouchDB.Driver.Database;
 using CouchDB.Driver.Local;
 using CouchDB.Driver.Security;
 using CouchDB.Driver.Types;
@@ -169,5 +170,10 @@ namespace CouchDB.Driver
         /// Access local documents operations.
         /// </summary>
         public ILocalDocuments LocalDocuments { get; }
+        
+        /// <summary>
+        /// index creator
+        /// </summary>
+        public IIndexProvider<TSource> IndexProvider { get; }         
     }
 }

--- a/src/CouchDB.Driver/Options/CouchOptions.cs
+++ b/src/CouchDB.Driver/Options/CouchOptions.cs
@@ -5,6 +5,7 @@ using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using Flurl.Http.Configuration;
+using Newtonsoft.Json;
 
 namespace CouchDB.Driver.Options
 {
@@ -29,6 +30,7 @@ namespace CouchDB.Driver.Options
 
         internal Func<HttpRequestMessage, X509Certificate2, X509Chain, SslPolicyErrors, bool>? ServerCertificateCustomValidationCallback { get; set; }
         internal Action<ClientFlurlHttpSettings>? ClientFlurlHttpSettingsAction { get; set; }
+        internal NullValueHandling? NullValueHandling { get; set; }
 
         internal CouchOptions()
         {

--- a/src/CouchDB.Driver/Options/CouchOptionsBuilder.cs
+++ b/src/CouchDB.Driver/Options/CouchOptionsBuilder.cs
@@ -6,6 +6,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using CouchDB.Driver.Helpers;
 using Flurl.Http.Configuration;
+using Newtonsoft.Json;
 
 namespace CouchDB.Driver.Options
 {
@@ -222,6 +223,12 @@ namespace CouchDB.Driver.Options
         public virtual CouchOptionsBuilder ConfigureFlurlClient(Action<ClientFlurlHttpSettings> flurlSettingsAction)
         {
             Options.ClientFlurlHttpSettingsAction = flurlSettingsAction;
+            return this;
+        }
+
+        public virtual CouchOptionsBuilder JsonNullValueHandling(NullValueHandling valueHandling)
+        {
+            Options.NullValueHandling = valueHandling;
             return this;
         }
     }

--- a/tests/CouchDB.Driver.E2ETests/Client_Tests.cs
+++ b/tests/CouchDB.Driver.E2ETests/Client_Tests.cs
@@ -9,6 +9,7 @@ using CouchDB.Driver.E2ETests;
 using CouchDB.Driver.E2ETests._Models;
 using CouchDB.Driver.Extensions;
 using CouchDB.Driver.Local;
+using CouchDB.Driver.Query.Extensions;
 using Xunit;
 
 namespace CouchDB.Driver.E2E
@@ -214,5 +215,37 @@ namespace CouchDB.Driver.E2E
             var containsId = docs.Select(d => d.Id).Contains("_local/" + docId);
             Assert.True(containsId);
         }
+
+        [Fact]
+        public async Task CreateIndex_Test()
+        {
+            var result = await _rebels.IndexProvider.CreateAsync(index =>
+            {
+                index.IndexName = "test-index";
+                index.Fields = x => new {x.Name, x.Age};
+            });
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task CreateAndUpdateIndex_Test()
+        {
+            var result = await _rebels.IndexProvider.CreateAsync(index =>
+            {
+                index.IndexName = "test-index";
+                index.Fields = x => new { x.Name, x.Age };
+            });
+            
+            Assert.True(result);
+            
+            var result2 = await _rebels.IndexProvider.CreateOrUpdateAsync(index =>
+            {
+                index.IndexName = "test-index";
+                index.Fields = x => new { x.Name, x.Age, x.Surname };
+            });
+            
+            Assert.True(result2);
+        }            
     }
 }


### PR DESCRIPTION
Allows the user to configure the handling with NULL values.

- default handling is unchanged

to setup remove null values

```
new CouchClient("http://localhost", x => x.JsonNullValueHandling(NullValueHandling.Ignore));
```