### PR TITLE
Fix Find() with conflicts. Must be ?confilcts=true, not ?conflicts=True

### DIFF
--- a/src/CouchDB.Driver/CouchDatabase.cs
+++ b/src/CouchDB.Driver/CouchDatabase.cs
@@ -29,7 +29,7 @@ namespace CouchDB.Driver
     /// Represents a CouchDB database.
     /// </summary>
     /// <typeparam name="TSource">The type of database documents.</typeparam>
-    public class CouchDatabase<TSource>: ICouchDatabase<TSource>
+    public class CouchDatabase<TSource> : ICouchDatabase<TSource>
         where TSource : CouchDocument
     {
         private readonly IAsyncQueryProvider _queryProvider;
@@ -75,7 +75,7 @@ namespace CouchDB.Driver
 
                 if (withConflicts)
                 {
-                    request = request.SetQueryParam("conflicts", true);
+                    request = request.SetQueryParam("conflicts", "true");
                 }
 
                 TSource document = await request
@@ -119,7 +119,7 @@ namespace CouchDB.Driver
                 .ReceiveJson<BulkGetResult<TSource>>()
                 .SendRequestAsync()
                 .ConfigureAwait(false);
-                       
+
             var documents = bulkGetResult.Results
                 .SelectMany(r => r.Docs)
                 .Select(d => d.Item)
@@ -345,7 +345,7 @@ namespace CouchDB.Driver
                 {
                     document.Rev = response.Rev;
                     document.Attachments.RemoveAttachment(attachment);
-                }                
+                }
             }
 
             InitAttachments(document);
@@ -398,7 +398,7 @@ namespace CouchDB.Driver
                     .ConfigureAwait(false)
                 : await request.QueryContinuousWithFilterAsync<TSource>(_options, filter, cancellationToken)
                     .ConfigureAwait(false);
-            
+
             await foreach (var line in stream.ReadLinesAsync(cancellationToken))
             {
                 if (string.IsNullOrEmpty(line))
@@ -481,7 +481,7 @@ namespace CouchDB.Driver
         #endregion
 
         #region Helper
-        
+
         /// <inheritdoc />
         public IFlurlRequest NewRequest()
         {

--- a/tests/CouchDB.Driver.UnitTests/Database_Tests.cs
+++ b/tests/CouchDB.Driver.UnitTests/Database_Tests.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace CouchDB.Driver.UnitTests
 {
-    public class Database_Tests: IAsyncDisposable
+    public class Database_Tests : IAsyncDisposable
     {
         private readonly ICouchClient _client;
         private readonly ICouchDatabase<Rebel> _rebels;
@@ -58,7 +58,8 @@ namespace CouchDB.Driver.UnitTests
             var newR = await _rebels.FindAsync("1", true);
             httpTest
                 .ShouldHaveCalled("http://localhost/rebels/1")
-                .WithQueryParamValue("conflicts", true)
+                // "true" must be lower case. Don't pass true as a bool. It will be serialized as "True"
+                .WithQueryParamValue("conflicts", "true")
                 .WithVerb(HttpMethod.Get);
         }
 


### PR DESCRIPTION
Conflicts aren't currently returned for `Find(id, withConflicts: true)` because .NET serializes `true` as `"True"` and CouchDb seems to ignore anything except `"true"`