### PR TITLE
Add CouchDB view support

### DIFF
--- a/src/CouchDB.Driver/CouchDatabase.cs
+++ b/src/CouchDB.Driver/CouchDatabase.cs
@@ -503,7 +503,23 @@ namespace CouchDB.Driver
         #region View
 
         /// <inheritdoc/>
-        public Task<CouchViewResult<TValue>> GetViewAsync<TValue>(string design, string view, CouchViewOptions? options = null, CancellationToken cancellationToken = default)
+        public async Task<IList<TRow>> GetViewAsync<TRow>(string design, string view, CouchViewOptions? options = null, CancellationToken cancellationToken = default)
+        {
+            CouchViewResult<TRow> result = await GetDetailedViewAsync<TRow>(design, view, options, cancellationToken).ConfigureAwait(false);
+
+            return result.Rows.Select(x => x.Value).ToArray();
+        }
+
+        /// <inheritdoc/>
+        public async Task<IList<(TRow Value, TSource Doc)>> GetViewWithDocAsync<TRow>(string design, string view, CouchViewOptions? options = null, CancellationToken cancellationToken = default)
+        {
+            CouchViewResult<TRow, TSource> result = await GetDetailedViewWithDocAsync<TRow>(design, view, options, cancellationToken).ConfigureAwait(false);
+
+            return result.Rows.Select(x => (x.Value, x.Doc)).ToArray();
+        }
+
+        /// <inheritdoc/>
+        public Task<CouchViewResult<TRow>> GetDetailedViewAsync<TRow>(string design, string view, CouchViewOptions? options = null, CancellationToken cancellationToken = default)
         {
             Check.NotNull(view, nameof(view));
 
@@ -512,13 +528,12 @@ namespace CouchDB.Driver
                 .SetQueryParams(options?.ToQueryParameters());
 
             return request
-                .GetJsonAsync<CouchViewResult<TValue>>(cancellationToken)
+                .GetJsonAsync<CouchViewResult<TRow>>(cancellationToken)
                 .SendRequestAsync();
         }
 
         /// <inheritdoc/>
-        public Task<CouchViewResult<TValue, TDoc>> GetViewAsync<TValue, TDoc>(string design, string view, CouchViewOptions? options = null, CancellationToken cancellationToken = default)
-            where TDoc : CouchDocument
+        public Task<CouchViewResult<TRow, TSource>> GetDetailedViewWithDocAsync<TRow>(string design, string view, CouchViewOptions? options = null, CancellationToken cancellationToken = default)
         {
             Check.NotNull(view, nameof(view));
 
@@ -530,7 +545,7 @@ namespace CouchDB.Driver
                 .SetQueryParams(options.ToQueryParameters());
 
             return request
-                .GetJsonAsync<CouchViewResult<TValue, TDoc>>(cancellationToken)
+                .GetJsonAsync<CouchViewResult<TRow, TSource>>(cancellationToken)
                 .SendRequestAsync();
         }
 

--- a/src/CouchDB.Driver/CouchDatabase.cs
+++ b/src/CouchDB.Driver/CouchDatabase.cs
@@ -500,6 +500,42 @@ namespace CouchDB.Driver
 
         #endregion
 
+        #region View
+
+        /// <inheritdoc/>
+        public Task<CouchViewResult<TValue>> GetViewAsync<TValue>(string design, string view, CouchViewOptions? options = null, CancellationToken cancellationToken = default)
+        {
+            Check.NotNull(view, nameof(view));
+
+            IFlurlRequest request = NewRequest()
+                .AppendPathSegments("_design", design, "_view", view)
+                .SetQueryParams(options?.ToQueryParameters());
+
+            return request
+                .GetJsonAsync<CouchViewResult<TValue>>(cancellationToken)
+                .SendRequestAsync();
+        }
+
+        /// <inheritdoc/>
+        public Task<CouchViewResult<TValue, TDoc>> GetViewAsync<TValue, TDoc>(string design, string view, CouchViewOptions? options = null, CancellationToken cancellationToken = default)
+            where TDoc : CouchDocument
+        {
+            Check.NotNull(view, nameof(view));
+
+            options ??= new CouchViewOptions();
+            options.IncludeDocs = true;
+
+            IFlurlRequest request = NewRequest()
+                .AppendPathSegments("_design", design, "_view", view)
+                .SetQueryParams(options.ToQueryParameters());
+
+            return request
+                .GetJsonAsync<CouchViewResult<TValue, TDoc>>(cancellationToken)
+                .SendRequestAsync();
+        }
+
+        #endregion
+
         #region Utils
 
         /// <inheritdoc />

--- a/src/CouchDB.Driver/ICouchDatabase.cs
+++ b/src/CouchDB.Driver/ICouchDatabase.cs
@@ -89,29 +89,50 @@ namespace CouchDB.Driver
         Task<IEnumerable<TSource>> AddOrUpdateRangeAsync(IList<TSource> documents, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Execute a couchdb view and get a result with the values.
+        /// Executes the specified view function from the specified design document.
         /// </summary>
-        /// <typeparam name="TValue">The type of the value that will be returned.</typeparam>
+        /// <typeparam name="TRow">The type of the value that will be returned.</typeparam>
         /// <param name="design">The design to use.</param>
         /// <param name="view">The view to use.</param>
         /// <param name="options">Optional options to pass to the view.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the <see cref="CouchViewResult{TValue}"/>.</returns>
-        Task<CouchViewResult<TValue>> GetViewAsync<TValue>(string design, string view, CouchViewOptions? options = null, CancellationToken cancellationToken = default);
+        Task<IList<TRow>> GetViewAsync<TRow>(string design, string view, CouchViewOptions? options = null, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Execute a couchdb view and get a result with the values and the docs.
+        /// Executes the specified view function from the specified design document. Additionally, it returns the document.
         /// </summary>
-        /// <typeparam name="TValue">The type of the value that will be returned.</typeparam>
-        /// <typeparam name="TDoc">The type of the document that will be returned.</typeparam>
+        /// <typeparam name="TRow">The type of the value that will be returned.</typeparam>
         /// <param name="design">The design to use.</param>
         /// <param name="view">The view to use.</param>
         /// <param name="options">Optional options to pass to the view.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the <see cref="CouchViewResult{TValue, TDoc}"/>.</returns>
         /// <remarks>The options IncludeDocs will always be set to true.</remarks>
-        Task<CouchViewResult<TValue, TDoc>> GetViewAsync<TValue, TDoc>(string design, string view, CouchViewOptions? options = null, CancellationToken cancellationToken = default)
-            where TDoc : CouchDocument;
+        Task<IList<(TRow Value, TSource Doc)>> GetViewWithDocAsync<TRow>(string design, string view, CouchViewOptions? options = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Executes the specified view function from the specified design document.
+        /// </summary>
+        /// <typeparam name="TRow">The type of the value that will be returned.</typeparam>
+        /// <param name="design">The design to use.</param>
+        /// <param name="view">The view to use.</param>
+        /// <param name="options">Optional options to pass to the view.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the <see cref="CouchViewResult{TValue}"/>.</returns>
+        Task<CouchViewResult<TRow>> GetDetailedViewAsync<TRow>(string design, string view, CouchViewOptions? options = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Executes the specified view function from the specified design document. Additionally, it returns the document.
+        /// </summary>
+        /// <typeparam name="TRow">The type of the value that will be returned.</typeparam>
+        /// <param name="design">The design to use.</param>
+        /// <param name="view">The view to use.</param>
+        /// <param name="options">Optional options to pass to the view.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the <see cref="CouchViewResult{TValue, TDoc}"/>.</returns>
+        /// <remarks>The options IncludeDocs will always be set to true.</remarks>
+        Task<CouchViewResult<TRow, TSource>> GetDetailedViewWithDocAsync<TRow>(string design, string view, CouchViewOptions? options = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Since CouchDB v3, it is deprecated (a no-op).

--- a/src/CouchDB.Driver/ICouchDatabase.cs
+++ b/src/CouchDB.Driver/ICouchDatabase.cs
@@ -89,6 +89,31 @@ namespace CouchDB.Driver
         Task<IEnumerable<TSource>> AddOrUpdateRangeAsync(IList<TSource> documents, CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Execute a couchdb view and get a result with the values.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the value that will be returned.</typeparam>
+        /// <param name="design">The design to use.</param>
+        /// <param name="view">The view to use.</param>
+        /// <param name="options">Optional options to pass to the view.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the <see cref="CouchViewResult{TValue}"/>.</returns>
+        Task<CouchViewResult<TValue>> GetViewAsync<TValue>(string design, string view, CouchViewOptions? options = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Execute a couchdb view and get a result with the values and the docs.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the value that will be returned.</typeparam>
+        /// <typeparam name="TDoc">The type of the document that will be returned.</typeparam>
+        /// <param name="design">The design to use.</param>
+        /// <param name="view">The view to use.</param>
+        /// <param name="options">Optional options to pass to the view.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the <see cref="CouchViewResult{TValue, TDoc}"/>.</returns>
+        /// <remarks>The options IncludeDocs will always be set to true.</remarks>
+        Task<CouchViewResult<TValue, TDoc>> GetViewAsync<TValue, TDoc>(string design, string view, CouchViewOptions? options = null, CancellationToken cancellationToken = default)
+            where TDoc : CouchDocument;
+
+        /// <summary>
         /// Since CouchDB v3, it is deprecated (a no-op).
         /// 
         /// Commits any recent changes to the specified database to disk. You should call this if you want to ensure that recent changes have been flushed.

--- a/src/CouchDB.Driver/Types/CouchViewOptions.cs
+++ b/src/CouchDB.Driver/Types/CouchViewOptions.cs
@@ -1,0 +1,169 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace CouchDB.Driver.Types
+{
+    /// <summary>
+    /// Optional options that can be send with a view request.
+    /// </summary>
+    public class CouchViewOptions
+    {
+        /// <summary>
+        ///  Include the associated document with each row. Default is false.
+        /// </summary>
+        public bool? IncludeDocs { get; set; }
+
+        /// <summary>
+        /// Include conflicts information in response.
+        /// Ignored if include_docs isn’t true. Default is false.
+        /// </summary>
+        public bool? Conflicts { get; set; }
+
+        /// <summary>
+        /// Return records starting with the specified key.
+        /// </summary>
+        public string? StartKey { get; set; }
+
+        /// <summary>
+        /// Stop returning records when the specified key is reached.
+        /// </summary>
+        public string? EndKey { get; set; }
+
+        /// <summary>
+        ///  Specifies whether the specified end key should
+        ///  be included in the result. Default is true.
+        /// </summary>
+        public bool? InclusiveEnd { get; set; }
+
+        /// <summary>
+        ///  Return the documents in descending order by key. Default is false.
+        /// </summary>
+        public bool? Descending { get; set; }
+
+        /// <summary>
+        ///  Group the results using the reduce function to a group or single row.
+        ///  Implies reduce is true and the maximum group_level. Default is false.
+        /// </summary>
+        public bool? Group { get; set; }
+
+        /// <summary>
+        /// Include encoding information in attachment stubs if include_docs is true
+        /// and the particular attachment is compressed.
+        /// Ignored if include_docs isn’t true. Default is false.
+        /// </summary>
+        public bool? AttEncodingInfo { get; set; }
+
+        /// <summary>
+        /// Use the reduction function. Default is true
+        /// when a reduce function is defined.
+        /// </summary>
+        public bool? Reduce { get; set; }
+
+        /// <summary>
+        /// Whether or not the view results should be returned
+        /// from a stable set of shards. Default is false.
+        /// </summary>
+        public bool? Stable { get; set; }
+
+        /// <summary>
+        /// Whether to include in the response an update_seq value indicating the
+        /// sequence id of the database the view reflects. Default is false.
+        /// </summary>
+        public bool? UpdateSeq { get; set; }
+
+        /// <summary>
+        /// Include the Base64-encoded content of
+        /// <see href="https://docs.couchdb.org/en/stable/api/document/common.html#api-doc-attachments">attachments</see>
+        /// in the documents that are included if include_docs is true.
+        /// Ignored if include_docs isn’t true. Default is false.
+        /// </summary>
+        public bool? Attachments { get; set; }
+
+        /// <summary>
+        /// Sort returned rows. Setting this to false offers a performance boost.
+        /// The total_rows and offset fields are not available when this is set to false.
+        /// Default is true.
+        /// </summary>
+        public bool? Sorted { get; set; }
+
+        /// <summary>
+        /// Specify the group level to be used. Implies group is true.
+        /// </summary>
+        public int? GroupLevel { get; set; }
+
+        /// <summary>
+        /// Limit the number of the returned documents to the specified number.
+        /// </summary>
+        public int? Limit { get; set; }
+
+        /// <summary>
+        ///  Skip this number of records before starting to return the results.
+        ///  Default is 0.
+        /// </summary>
+        public int? Skip { get; set; }
+
+        /// <summary>
+        /// Whether or not the view in question should be updated prior to responding to the user.
+        /// Supported values: true, false, lazy. Default is true.
+        /// </summary>
+        public string? Update { get; set; }
+
+        /// <summary>
+        ///  Stop returning records when the specified document ID is reached.
+        ///  Ignored if endkey is not set.
+        /// </summary>
+        public string? EndkeyDocId { get; set; }
+
+        /// <summary>
+        /// Return only documents that match the specified key.
+        /// </summary>
+        public string? Key { get; set; }
+
+        /// <summary>
+        /// Return records starting with the specified document ID.
+        /// Ignored if startkey is not set.
+        /// </summary>
+        public string? StartkeyDocid { get; set; }
+
+        // Error CA2227: Change 'Keys' to be read-only by removing the property setter.
+        // Disable this so keys can be added in with other properties on initialization.
+#pragma warning disable CA2227
+        /// <summary>
+        /// Return only documents where the key matches one of the keys specified in the array.
+        /// </summary>
+        public HashSet<string>? Keys { get; set; }
+
+#pragma warning restore CA2227
+
+        public object ToQueryParameters() => new
+        {
+            include_docs = IncludeDocs,
+            conflicts = Conflicts,
+            startkey = TryEscape(StartKey),
+            endKey = TryEscape(EndKey),
+            inclusive_end = InclusiveEnd,
+            descending = Descending,
+            group = Group,
+            att_encoding_info = AttEncodingInfo,
+            reduce = Reduce,
+            stable = Stable,
+            update_seq = UpdateSeq,
+            attachments = Attachments,
+            sorted = Sorted,
+            group_level = GroupLevel,
+            limit = Limit,
+            skip = Skip,
+            update = TryEscape(Update),
+            endkey_docid = TryEscape(EndkeyDocId),
+            key = TryEscape(Key),
+            startkey_docid = TryEscape(StartkeyDocid),
+            keys = Keys is null ? null : $"[{string.Join(',', Keys.Select(Escape))}]"
+        };
+
+        private static string Escape(string str) =>
+            $"\"{str}\"";
+
+        private static string? TryEscape(string? str) =>
+            str is null ? null : Escape(str);
+    }
+}

--- a/src/CouchDB.Driver/Types/CouchViewResult.cs
+++ b/src/CouchDB.Driver/Types/CouchViewResult.cs
@@ -1,0 +1,59 @@
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace CouchDB.Driver.Types
+{
+    /// <summary>
+    /// Object that stores results of a view.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value.</typeparam>
+    public class CouchViewResult<TValue>
+    {
+        /// <summary>
+        /// Number of documents in the database/view.
+        /// </summary>
+        [JsonProperty("total_rows")]
+        public int TotalRows { get; private set; }
+
+        /// <summary>
+        /// Offset where the document list started.
+        /// </summary>
+        [JsonProperty("offset")]
+        public int Offset { get; private set; }
+
+        /// <summary>
+        /// Array of view row objects. This result contains only the document ID and revision.
+        /// </summary>
+        [JsonProperty("rows")]
+        public IReadOnlyList<CouchViewRow<TValue>> Rows { get; private set; } = ImmutableArray.Create<CouchViewRow<TValue>>();
+    }
+
+    /// <summary>
+    /// Object that stores results of a view.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value.</typeparam>
+    /// <typeparam name="TDoc">The type of the doc.</typeparam>
+    public class CouchViewResult<TValue, TDoc>
+        where TDoc : CouchDocument
+
+    {
+        /// <summary>
+        /// Number of documents in the database/view.
+        /// </summary>
+        [JsonProperty("total_rows")]
+        public int TotalRows { get; private set; }
+
+        /// <summary>
+        /// Offset where the document list started.
+        /// </summary>
+        [JsonProperty("offset")]
+        public int Offset { get; private set; }
+
+        /// <summary>
+        /// Array of view row objects. This result contains the document ID, revision and the documents.
+        /// </summary>
+        [JsonProperty("rows")]
+        public IReadOnlyList<CouchViewRow<TValue, TDoc>> Rows { get; private set; } = ImmutableArray.Create<CouchViewRow<TValue, TDoc>>();
+    }
+}

--- a/src/CouchDB.Driver/Types/CouchViewResult.cs
+++ b/src/CouchDB.Driver/Types/CouchViewResult.cs
@@ -7,8 +7,8 @@ namespace CouchDB.Driver.Types
     /// <summary>
     /// Object that stores results of a view.
     /// </summary>
-    /// <typeparam name="TValue">The type of the value.</typeparam>
-    public class CouchViewResult<TValue>
+    /// <typeparam name="TRow">The type of the value.</typeparam>
+    public class CouchViewResult<TRow>
     {
         /// <summary>
         /// Number of documents in the database/view.
@@ -26,17 +26,16 @@ namespace CouchDB.Driver.Types
         /// Array of view row objects. This result contains only the document ID and revision.
         /// </summary>
         [JsonProperty("rows")]
-        public IReadOnlyList<CouchViewRow<TValue>> Rows { get; private set; } = ImmutableArray.Create<CouchViewRow<TValue>>();
+        public IReadOnlyList<CouchViewRow<TRow>> Rows { get; private set; } = ImmutableArray.Create<CouchViewRow<TRow>>();
     }
 
     /// <summary>
     /// Object that stores results of a view.
     /// </summary>
     /// <typeparam name="TValue">The type of the value.</typeparam>
-    /// <typeparam name="TDoc">The type of the doc.</typeparam>
-    public class CouchViewResult<TValue, TDoc>
-        where TDoc : CouchDocument
-
+    /// <typeparam name="TSource">The type of the doc.</typeparam>
+    public class CouchViewResult<TRow, TSource>
+        where TSource : CouchDocument
     {
         /// <summary>
         /// Number of documents in the database/view.
@@ -54,6 +53,6 @@ namespace CouchDB.Driver.Types
         /// Array of view row objects. This result contains the document ID, revision and the documents.
         /// </summary>
         [JsonProperty("rows")]
-        public IReadOnlyList<CouchViewRow<TValue, TDoc>> Rows { get; private set; } = ImmutableArray.Create<CouchViewRow<TValue, TDoc>>();
+        public IReadOnlyList<CouchViewRow<TRow, TSource>> Rows { get; private set; } = ImmutableArray.Create<CouchViewRow<TRow, TSource>>();
     }
 }

--- a/src/CouchDB.Driver/Types/CouchViewRow.cs
+++ b/src/CouchDB.Driver/Types/CouchViewRow.cs
@@ -1,0 +1,41 @@
+﻿using Newtonsoft.Json;
+
+namespace CouchDB.Driver.Types
+{
+    /// <summary>
+    /// The object returned from a view execution.
+    /// </summary>
+    /// <typeparam name="TValue">The type the value will be deserialized to.</typeparam>
+    public class CouchViewRow<TValue>
+    {
+        /// <summary>
+        /// The id of the document.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; private set; } = null!;
+
+        /// <summary>
+        /// The view key that was emmited.
+        /// </summary>
+        [JsonProperty("key")]
+        public string Key { get; private set; } = null!;
+
+        /// <summary>
+        /// The value that the view emmited.
+        /// </summary>
+        [JsonProperty("value")]
+        public TValue Value { get; private set; } = default!;
+    }
+
+    /// <inheritdoc/>
+    /// <typeparam name="TDoc">The type the doc will be deserialized to.</typeparam>
+    public class CouchViewRow<TValue, TDoc> : CouchViewRow<TValue>
+        where TDoc : CouchDocument
+    {
+        /// <summary>
+        /// The json document deserialize to <see cref="TDoc"/>.
+        /// </summary>
+        [JsonProperty("doc")]
+        public TDoc Doc { get; private set; } = default!;
+    }
+}


### PR DESCRIPTION
I created these classes and used them with extension methods to get views from CouchDB and I thought it would be great for it to be included in this awesome library. If you don't like something please do tell me to fix it.

Also, I deliberately turned off `Error CA2227: Change 'Keys' to be read-only by removing the property setter.` so that this along with any other options can be set at the same time using class initializers.