### PR TITLE
Fix CouchViewOptions

### DIFF
--- a/src/CouchDB.Driver/Helpers/CouchContractResolver.cs
+++ b/src/CouchDB.Driver/Helpers/CouchContractResolver.cs
@@ -24,18 +24,6 @@ namespace CouchDB.Driver.Helpers
             if (property != null && !property.Ignored)
             {
                 property.PropertyName = member.GetCouchPropertyName(_propertyCaseType);
-
-                DefaultValueAttribute? defaultValueAttribute = member.GetCustomAttribute<DefaultValueAttribute>();
-                if (defaultValueAttribute != null && member is PropertyInfo propertyInfo)
-                {
-                    property.ShouldSerialize =
-                        instance =>
-                        {
-                            object? value = propertyInfo.GetValue(instance);
-                            var shouldSerialize = !Equals(value, defaultValueAttribute.Value);
-                            return shouldSerialize;
-                        };
-                }
             }
             return property;
         }

--- a/src/CouchDB.Driver/Views/CouchViewOptions.cs
+++ b/src/CouchDB.Driver/Views/CouchViewOptions.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-#pragma warning disable CA2227 // Collection properties should be read only
+﻿#pragma warning disable CA2227 // Collection properties should be read only
 using System.Collections.Generic;
 using System.ComponentModel;
 using Newtonsoft.Json;
@@ -16,111 +15,111 @@ namespace CouchDB.Driver.Views
         /// Include conflicts information in response.
         /// Ignored if <see cref="IncludeDocs"/> isn't <c>True</c>. Default is <c>False</c>.
         /// </summary>
-        [JsonProperty("conflicts")]
-        [DefaultValue(false)]
-        public bool Conflicts { get; set; }
+        [JsonProperty("conflicts", NullValueHandling = NullValueHandling.Ignore)]
+        [DefaultValue(null)]
+        public bool? Conflicts { get; set; }
 
         /// <summary>
         /// Return the documents in descending order by key. Default is <c>False</c>.
         /// </summary>
-        [JsonProperty("descending")]
-        [DefaultValue(false)]
-        public bool Descending { get; set; }
+        [JsonProperty("descending", NullValueHandling = NullValueHandling.Ignore)]
+        [DefaultValue(null)]
+        public bool? Descending { get; set; }
 
         /// <summary>
         /// Stop returning records when the specified key is reached.
         /// </summary>
-        [JsonProperty("endkey")]
+        [JsonProperty("endkey", NullValueHandling = NullValueHandling.Ignore)]
         [DefaultValue(null)]
-        public TKey EndKey { get; set; }
+        public TKey? EndKey { get; set; }
 
         /// <summary>
         ///  Stop returning records when the specified document ID is reached.
         ///  Ignored if <see cref="EndKey"/> is not set.
         /// </summary>
-        [JsonProperty("endkey_docid")]
+        [JsonProperty("endkey_docid", NullValueHandling = NullValueHandling.Ignore)]
         [DefaultValue(null)]
-        public string EndKeyDocId { get; set; }
+        public string? EndKeyDocId { get; set; }
 
         /// <summary>
         ///  Group the results using the reduce function to a group or single row.
         ///  Implies reduce is <c>True</c> and the maximum <see cref="GroupLevel"/>. Default is <c>False</c>.
         /// </summary>
-        [JsonProperty("group")]
-        [DefaultValue(false)]
-        public bool Group { get; set; }
+        [JsonProperty("group", NullValueHandling = NullValueHandling.Ignore)]
+        [DefaultValue(null)]
+        public bool? Group { get; set; }
 
         /// <summary>
         /// Specify the group level to be used. Implies group is <c>True</c>.
         /// </summary>
-        [JsonProperty("group_level")]
+        [JsonProperty("group_level", NullValueHandling = NullValueHandling.Ignore)]
         [DefaultValue(null)]
         public int? GroupLevel { get; set; }
 
         /// <summary>
         ///  Include the associated document with each row. Default is <c>False</c>.
         /// </summary>
-        [JsonProperty("include_docs")]
-        [DefaultValue(false)]
-        public bool IncludeDocs { get; set; }
+        [JsonProperty("include_docs", NullValueHandling = NullValueHandling.Ignore)]
+        [DefaultValue(null)]
+        public bool? IncludeDocs { get; set; }
 
         /// <summary>
         /// Include the Base64-encoded content of attachments in the documents that are included if <see cref="IncludeDocs"/> is <c>True</c>.
         /// Ignored if <see cref="IncludeDocs"/> isn’t <c>True</c>. Default is <c>False</c>.
         /// </summary>
-        [JsonProperty("attachments")]
-        [DefaultValue(false)]
-        public bool Attachments { get; set; }
+        [JsonProperty("attachments", NullValueHandling = NullValueHandling.Ignore)]
+        [DefaultValue(null)]
+        public bool? Attachments { get; set; }
 
         /// <summary>
         /// Include encoding information in attachment stubs if <see cref="IncludeDocs"/> is <c>True</c> and the particular attachment is compressed.
         /// Ignored if <see cref="IncludeDocs"/> isn’t <c>True</c>. Default is <c>False</c>.
         /// </summary>
-        [JsonProperty("att_encoding_info")]
-        [DefaultValue(false)]
-        public bool AttachEncodingInfo { get; set; }
+        [JsonProperty("att_encoding_info", NullValueHandling = NullValueHandling.Ignore)]
+        [DefaultValue(null)]
+        public bool? AttachEncodingInfo { get; set; }
 
         /// <summary>
         ///  Specifies whether the specified end key should be included in the result. Default is <c>True</c>.
         /// </summary>
-        [JsonProperty("inclusive_end")]
-        [DefaultValue(true)]
-        public bool InclusiveEnd { get; set; } = true;
+        [JsonProperty("inclusive_end", NullValueHandling = NullValueHandling.Ignore)]
+        [DefaultValue(null)]
+        public bool? InclusiveEnd { get; set; }
 
         /// <summary>
         /// Return only documents that match the specified key.
         /// </summary>
-        [JsonProperty("key")]
+        [JsonProperty("key", NullValueHandling = NullValueHandling.Ignore)]
         [DefaultValue(null)]
-        public TKey Key { get; set; }
+        public TKey? Key { get; set; }
 
         /// <summary>
         /// Return only documents where the key matches one of the keys specified in the array.
         /// </summary>
-        [JsonProperty("keys")]
+        [JsonProperty("keys", NullValueHandling = NullValueHandling.Ignore)]
         [DefaultValue(null)]
-        public IList<TKey> Keys { get; set; }
+        public IList<TKey>? Keys { get; set; }
 
         /// <summary>
         /// Limit the number of the returned documents to the specified number.
         /// </summary>
-        [JsonProperty("limit")]
+        [JsonProperty("limit", NullValueHandling = NullValueHandling.Ignore)]
         [DefaultValue(null)]
         public int? Limit { get; set; }
 
         /// <summary>
         /// Use the reduction function. Default is <c>True</c> when a reduce function is defined.
         /// </summary>
-        [JsonProperty("reduce")]
-        [DefaultValue(false)]
-        public bool Reduce { get; set; }
+        [JsonProperty("reduce", NullValueHandling = NullValueHandling.Ignore)]
+        [DefaultValue(null)]
+        public bool? Reduce { get; set; }
 
         /// <summary>
         /// Skip this number of records before starting to return the results. Default is <code>0</code>.
         /// </summary>
-        [JsonProperty("skip")]
-        [DefaultValue(0)]
-        public int Skip { get; set; }
+        [JsonProperty("skip", NullValueHandling = NullValueHandling.Ignore)]
+        [DefaultValue(null)]
+        public int? Skip { get; set; }
 
         /// <summary>
         /// Sort returned rows (see Sorting <see href="https://docs.couchdb.org/en/stable/api/ddoc/views.html#api-ddoc-view-sorting"></see> Returned Rows).
@@ -128,50 +127,53 @@ namespace CouchDB.Driver.Views
         /// The <see cref="CouchViewResult{TKey, TRow}.TotalRows"/> and <see cref="CouchViewResult{TKey, TRow}.Offset"/> fields are not available when this is set to <c>False</c>.
         /// Default is <c>True</c>.
         /// </summary>
-        [JsonProperty("sorted")]
-        [DefaultValue(true)]
-        public bool Sorted { get; set; } = true;
+        [JsonProperty("sorted", NullValueHandling = NullValueHandling.Ignore)]
+        [DefaultValue(null)]
+        public bool? Sorted { get; set; }
 
         /// <summary>
-        /// Whether or not the view results should be returned from a stable set of shards. Default is <c>False</c>.
+        /// Whether or not the view results should be returned from a stable set of shards.
+        /// Supported values <see cref="StableStyle.True"/>, <see cref="StableStyle.False"/>. Default is <see cref="StableStyle.False"/>
         /// </summary>
-        [JsonProperty("stable")]
-        [DefaultValue(false)]
-        public bool Stable { get; set; }
+        [JsonIgnore]
+        public StableStyle? Stable { get; set; }
+
+        [JsonProperty("stable", NullValueHandling = NullValueHandling.Ignore)]
+        [DefaultValue(null)]
+        internal string? StableString => Stable?.ToString();
 
         /// <summary>
         /// Return records starting with the specified key.
         /// </summary>
-        [JsonProperty("startkey")]
+        [JsonProperty("startkey", NullValueHandling = NullValueHandling.Ignore)]
         [DefaultValue(null)]
-        public TKey StartKey { get; set; }
+        public TKey? StartKey { get; set; }
 
         /// <summary>
         /// Return records starting with the specified document ID. Ignored if <see cref="StartKey"/> is not set.
         /// </summary>
-        [JsonProperty("startkey_docid")]
+        [JsonProperty("startkey_docid", NullValueHandling = NullValueHandling.Ignore)]
         [DefaultValue(null)]
-        public string StartKeyDocId { get; set; }
+        public string? StartKeyDocId { get; set; }
 
         /// <summary>
         /// Whether or not the view in question should be updated prior to responding to the user.
         /// Supported values: <see cref="UpdateStyle.True"/>, <see cref="UpdateStyle.False"/>, <see cref="UpdateStyle.Lazy"/>. Default is <see cref="UpdateStyle.True"/>.
         /// </summary>
         [JsonIgnore]
-        public UpdateStyle Update { get; set; } = UpdateStyle.True;
+        public UpdateStyle? Update { get; set; }
 
-        [JsonProperty("update")]
-        [DefaultValue("true")]
-        internal string UpdateString => Update.ToString();
+        [JsonProperty("update", NullValueHandling = NullValueHandling.Ignore)]
+        [DefaultValue(null)]
+        internal string? UpdateString => Update?.ToString();
 
         /// <summary>
         /// Whether to include in the response an <see cref="UpdateSeq"/> value indicating the sequence id of the database the view reflects.
         /// Default is <c>False</c>.
         /// </summary>
-        [JsonProperty("update_seq")]
-        [DefaultValue(false)]
-        public bool UpdateSeq { get; set; }
+        [JsonProperty("update_seq", NullValueHandling = NullValueHandling.Ignore)]
+        [DefaultValue(null)]
+        public bool? UpdateSeq { get; set; }
     }
 }
 #pragma warning restore CA2227 // Collection properties should be read only
-#nullable restore

--- a/src/CouchDB.Driver/Views/CouchViewOptions.cs
+++ b/src/CouchDB.Driver/Views/CouchViewOptions.cs
@@ -16,21 +16,18 @@ namespace CouchDB.Driver.Views
         /// Ignored if <see cref="IncludeDocs"/> isn't <c>True</c>. Default is <c>False</c>.
         /// </summary>
         [JsonProperty("conflicts", NullValueHandling = NullValueHandling.Ignore)]
-        [DefaultValue(null)]
         public bool? Conflicts { get; set; }
 
         /// <summary>
         /// Return the documents in descending order by key. Default is <c>False</c>.
         /// </summary>
         [JsonProperty("descending", NullValueHandling = NullValueHandling.Ignore)]
-        [DefaultValue(null)]
         public bool? Descending { get; set; }
 
         /// <summary>
         /// Stop returning records when the specified key is reached.
         /// </summary>
         [JsonProperty("endkey", NullValueHandling = NullValueHandling.Ignore)]
-        [DefaultValue(null)]
         public TKey? EndKey { get; set; }
 
         /// <summary>
@@ -38,7 +35,6 @@ namespace CouchDB.Driver.Views
         ///  Ignored if <see cref="EndKey"/> is not set.
         /// </summary>
         [JsonProperty("endkey_docid", NullValueHandling = NullValueHandling.Ignore)]
-        [DefaultValue(null)]
         public string? EndKeyDocId { get; set; }
 
         /// <summary>
@@ -46,21 +42,18 @@ namespace CouchDB.Driver.Views
         ///  Implies reduce is <c>True</c> and the maximum <see cref="GroupLevel"/>. Default is <c>False</c>.
         /// </summary>
         [JsonProperty("group", NullValueHandling = NullValueHandling.Ignore)]
-        [DefaultValue(null)]
         public bool? Group { get; set; }
 
         /// <summary>
         /// Specify the group level to be used. Implies group is <c>True</c>.
         /// </summary>
         [JsonProperty("group_level", NullValueHandling = NullValueHandling.Ignore)]
-        [DefaultValue(null)]
         public int? GroupLevel { get; set; }
 
         /// <summary>
         ///  Include the associated document with each row. Default is <c>False</c>.
         /// </summary>
         [JsonProperty("include_docs", NullValueHandling = NullValueHandling.Ignore)]
-        [DefaultValue(null)]
         public bool? IncludeDocs { get; set; }
 
         /// <summary>
@@ -68,7 +61,6 @@ namespace CouchDB.Driver.Views
         /// Ignored if <see cref="IncludeDocs"/> isn’t <c>True</c>. Default is <c>False</c>.
         /// </summary>
         [JsonProperty("attachments", NullValueHandling = NullValueHandling.Ignore)]
-        [DefaultValue(null)]
         public bool? Attachments { get; set; }
 
         /// <summary>
@@ -76,49 +68,42 @@ namespace CouchDB.Driver.Views
         /// Ignored if <see cref="IncludeDocs"/> isn’t <c>True</c>. Default is <c>False</c>.
         /// </summary>
         [JsonProperty("att_encoding_info", NullValueHandling = NullValueHandling.Ignore)]
-        [DefaultValue(null)]
         public bool? AttachEncodingInfo { get; set; }
 
         /// <summary>
         ///  Specifies whether the specified end key should be included in the result. Default is <c>True</c>.
         /// </summary>
         [JsonProperty("inclusive_end", NullValueHandling = NullValueHandling.Ignore)]
-        [DefaultValue(null)]
         public bool? InclusiveEnd { get; set; }
 
         /// <summary>
         /// Return only documents that match the specified key.
         /// </summary>
         [JsonProperty("key", NullValueHandling = NullValueHandling.Ignore)]
-        [DefaultValue(null)]
         public TKey? Key { get; set; }
 
         /// <summary>
         /// Return only documents where the key matches one of the keys specified in the array.
         /// </summary>
         [JsonProperty("keys", NullValueHandling = NullValueHandling.Ignore)]
-        [DefaultValue(null)]
         public IList<TKey>? Keys { get; set; }
 
         /// <summary>
         /// Limit the number of the returned documents to the specified number.
         /// </summary>
         [JsonProperty("limit", NullValueHandling = NullValueHandling.Ignore)]
-        [DefaultValue(null)]
         public int? Limit { get; set; }
 
         /// <summary>
         /// Use the reduction function. Default is <c>True</c> when a reduce function is defined.
         /// </summary>
         [JsonProperty("reduce", NullValueHandling = NullValueHandling.Ignore)]
-        [DefaultValue(null)]
         public bool? Reduce { get; set; }
 
         /// <summary>
         /// Skip this number of records before starting to return the results. Default is <code>0</code>.
         /// </summary>
         [JsonProperty("skip", NullValueHandling = NullValueHandling.Ignore)]
-        [DefaultValue(null)]
         public int? Skip { get; set; }
 
         /// <summary>
@@ -128,7 +113,6 @@ namespace CouchDB.Driver.Views
         /// Default is <c>True</c>.
         /// </summary>
         [JsonProperty("sorted", NullValueHandling = NullValueHandling.Ignore)]
-        [DefaultValue(null)]
         public bool? Sorted { get; set; }
 
         /// <summary>
@@ -139,21 +123,18 @@ namespace CouchDB.Driver.Views
         public StableStyle? Stable { get; set; }
 
         [JsonProperty("stable", NullValueHandling = NullValueHandling.Ignore)]
-        [DefaultValue(null)]
         internal string? StableString => Stable?.ToString();
 
         /// <summary>
         /// Return records starting with the specified key.
         /// </summary>
         [JsonProperty("startkey", NullValueHandling = NullValueHandling.Ignore)]
-        [DefaultValue(null)]
         public TKey? StartKey { get; set; }
 
         /// <summary>
         /// Return records starting with the specified document ID. Ignored if <see cref="StartKey"/> is not set.
         /// </summary>
         [JsonProperty("startkey_docid", NullValueHandling = NullValueHandling.Ignore)]
-        [DefaultValue(null)]
         public string? StartKeyDocId { get; set; }
 
         /// <summary>
@@ -164,7 +145,6 @@ namespace CouchDB.Driver.Views
         public UpdateStyle? Update { get; set; }
 
         [JsonProperty("update", NullValueHandling = NullValueHandling.Ignore)]
-        [DefaultValue(null)]
         internal string? UpdateString => Update?.ToString();
 
         /// <summary>
@@ -172,7 +152,6 @@ namespace CouchDB.Driver.Views
         /// Default is <c>False</c>.
         /// </summary>
         [JsonProperty("update_seq", NullValueHandling = NullValueHandling.Ignore)]
-        [DefaultValue(null)]
         public bool? UpdateSeq { get; set; }
     }
 }

--- a/src/CouchDB.Driver/Views/StableStyle.cs
+++ b/src/CouchDB.Driver/Views/StableStyle.cs
@@ -1,0 +1,30 @@
+﻿namespace CouchDB.Driver.Views
+{
+    /// <summary>
+    /// Whether or not the view results should be returned from a stable set of shards.
+    /// </summary>
+    public class StableStyle
+    {
+        private readonly string _value;
+
+        /// <summary>
+        /// The view results will be returned from a stable set of shards.
+        /// </summary>
+        public static StableStyle True => new("true");
+
+        /// <summary>
+        /// The view results will be returned from an unstable set of shards.
+        /// </summary>
+        public static StableStyle False => new("false");
+
+        private StableStyle(string value)
+        {
+            _value = value;
+        }
+
+        public override string ToString()
+        {
+            return _value;
+        }
+    }
+}


### PR DESCRIPTION
Hey as I was using it across a project and running some tests I came across some errors when using the `CouchViewOptions`.

So I changed all values to have a `null`  default value and also be Ignored by the serializer.
This fixes a bad request error for including values as null that don't support it on the server like the following
- `group_level`
- `keys`
- `limit`

Changed `stable` to use a class like `update` since I discovered it says that it is a boolean but it needs to be in a string form.

I used a view and a client like Postman and C# to test again all values and these were the only problem.

I believe leaving all values null and as part not included until a user sets them explicitly is better since it only sends the settings the user chooses to, the DB uses its defaults and it might even decrease the payload sent to the DB if someone cares that much about it.

I also tried sending empty options and It works as expected.

Sorry for taking so long to discover these I was busy with some other projects and didn't get to use the Implementation as soon as I wanted.