### PR TITLE
Add support for regex multiline, via Any IsMatch

### DIFF
--- a/src/CouchDB.Driver/Query/Translators/MethodCallExpressionTranslator.cs
+++ b/src/CouchDB.Driver/Query/Translators/MethodCallExpressionTranslator.cs
@@ -170,7 +170,7 @@ namespace CouchDB.Driver.Query
 
             throw new NotSupportedException($"The method '{m.Method.Name}' is not supported");
         }
-        
+
         #region Queryable
 
         private Expression VisitWhereMethod(MethodCallExpression m)
@@ -219,7 +219,7 @@ namespace CouchDB.Driver.Query
         {
             void InspectOrdering(Expression e)
             {
-                MethodCallExpression o = e as MethodCallExpression?? throw new AuthenticationException($"Invalid expression type {e.GetType().Name}");
+                MethodCallExpression o = e as MethodCallExpression ?? throw new AuthenticationException($"Invalid expression type {e.GetType().Name}");
                 Expression lambdaBody = o.GetLambdaBody();
 
                 switch (o.Method.Name)
@@ -494,10 +494,18 @@ namespace CouchDB.Driver.Query
         private Expression VisitIsMatchMethod(MethodCallExpression m)
         {
             _sb.Append('{');
+
             Visit(m.Arguments[0]);
-            _sb.Append(":{\"$regex\":");
+            var isParameter = m.Arguments[0].NodeType == ExpressionType.Parameter;
+            if (!isParameter)
+            {
+                _sb.Append(":{");
+            }
+
+            _sb.Append("\"$regex\":");
             Visit(m.Arguments[1]);
-            _sb.Append("}}");
+            _sb.Append(!isParameter ? "}}" : "}");
+
             return m;
         }
 

--- a/tests/CouchDB.Driver.UnitTests/Find/Find_Selector_Conditions.cs
+++ b/tests/CouchDB.Driver.UnitTests/Find/Find_Selector_Conditions.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using CouchDB.Driver.Query.Extensions;
 using Xunit;
+using System.Text.RegularExpressions;
 
 namespace CouchDB.Driver.UnitTests.Find
 {
@@ -142,6 +143,13 @@ namespace CouchDB.Driver.UnitTests.Find
         {
             var json = _rebels.Where(r => r.Name.IsMatch(@"^FN-[0-9]{4}$")).ToString();
             Assert.Equal(@"{""selector"":{""name"":{""$regex"":""^FN-[0-9]{4}$""}}}", json);
+        }
+
+        [Fact]
+        public void Miscellaneous_RegexMultiLine()
+        {
+            var json = _rebels.Where(r => r.Skills.Any(s => s.IsMatch($"(?i)sab") || s.IsMatch($"(?)orce"))).ToString();
+            Assert.Equal(@"{""selector"":{""skills"":{""$elemMatch"":{""$or"":[{""$regex"":""(?i)sab""},{""$regex"":""(?)orce""}]}}}}", json);
         }
 
         #endregion


### PR DESCRIPTION
Add support for regex multiline, via Any IsMatch.

It's very important to keep existing functionality as before, so this was covered by unit tests, for a single string, but also for a collection of strings.