### PR TITLE
Fixes Bad Request on Attachment Upload

### DIFF
--- a/src/CouchDB.Driver/Converters/AttachmentsParsedConverter.cs
+++ b/src/CouchDB.Driver/Converters/AttachmentsParsedConverter.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using CouchDB.Driver.Types;
+using Newtonsoft.Json;
+
+namespace CouchDB.Driver.Converters
+{
+    internal class AttachmentsParsedConverter : JsonConverter<Dictionary<string, CouchAttachment>>
+    {
+        public override void WriteJson(JsonWriter writer, Dictionary<string, CouchAttachment> value,
+            JsonSerializer serializer)
+        {
+            serializer.Serialize(writer, value
+                .Where(kvp => kvp.Value.FileInfo is null)
+                .ToDictionary(k => k.Key, v => v.Value)
+            );
+        }
+
+        public override bool CanRead => false;
+
+        public override Dictionary<string, CouchAttachment> ReadJson(JsonReader reader, Type objectType,
+            Dictionary<string, CouchAttachment> existingValue, bool hasExistingValue,
+            JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/CouchDB.Driver/Types/CouchDocument.cs
+++ b/src/CouchDB.Driver/Types/CouchDocument.cs
@@ -1,6 +1,7 @@
 ﻿#nullable disable
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+using CouchDB.Driver.Converters;
 using Newtonsoft.Json;
 
 namespace CouchDB.Driver.Types
@@ -47,6 +48,7 @@ namespace CouchDB.Driver.Types
         // This must be for serialization only field
         [DataMember]
         [JsonProperty("_attachments", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonConverter(typeof(AttachmentsParsedConverter))]
         private Dictionary<string, CouchAttachment> AttachmentsParsed { get; set; }
 
         [JsonIgnore]


### PR DESCRIPTION
Fixes #163 

CouchDB v3.2.1 (in my test scenario) refuses a document update when one or more  attachments were added because of incomplete attachment meta data created by the serializer. I solved this by adding a JSON converter which ignores new attachments in the PUT request.