### PR TITLE
Fixed 32-bit integer overflow in GetInfoAsync()

### DIFF
--- a/src/CouchDB.Driver/Types/Sizes.cs
+++ b/src/CouchDB.Driver/Types/Sizes.cs
@@ -11,18 +11,18 @@ namespace CouchDB.Driver.Types
         /// The size of the database file on disk in bytes. Views indexes are not included in the calculation.
         /// </summary>
         [JsonProperty("file")]
-        public int File { get; internal set; }
+        public long File { get; internal set; }
 
         /// <summary>
         /// The uncompressed size of database contents in bytes.
         /// </summary>
         [JsonProperty("external")]
-        public int External { get; internal set; }
+        public long External { get; internal set; }
 
         /// <summary>
         /// The size of live data inside the database, in bytes.
         /// </summary>
         [JsonProperty("active")]
-        public int Active { get; internal set; }
+        public long Active { get; internal set; }
     }
 }


### PR DESCRIPTION
If you call `GetInfoAsync()` on a database that exceeds 2 GB you'll encounter the following issue:

```
Newtonsoft.Json.JsonReaderException: 'JSON integer 5111222718 is too large or small for an Int32. Path 'sizes.file', line 1, position 294.'
```

This PR simply switches the relevant fields from `int` to `long` which fixes the error.