### PR TITLE
Support for revisions in Find, AddOrUpdate

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,14 +393,12 @@ Stream responseStream = await rebels.DownloadAttachmentAsStreamAsync(attachment)
 
 ## Revisions
 
-The options for 'FindAsync(..)' and 'AddOrUpdateAsync(..)' support passing revision:
+The options for `FindAsync(..)` and `AddOrUpdateAsync(..)` support passing revision:
 
 ```csharp
 await _rebels.FindAsync("1", new FindOptions { Rev = "1-xxx" });
 await _rebels.AddOrUpdateAsync(r, new AddOrUpdateOptions { Rev = "1-xxx" });
 ```
-
-Options also can be used to pass 'Batch', 'Conflicts' where applicable.
 
 For attachements revisions are supported by 'CouchAttachment' class which is passing 'DocumentRev' to 'DownloadAttachmentAsync(..)' and 'DownloadAttachmentAsStreamAsync(..)'.
 

--- a/README.md
+++ b/README.md
@@ -268,9 +268,7 @@ var tasks = await client.GetActiveTasksAsync();
 ```csharp
 // CRUD
 await rebels.AddAsync(rebel);
-await rebels.AddAsync(rebel, batch: true);
 await rebels.AddOrUpdateAsync(rebel);
-await rebels.AddOrUpdateAsync(rebel, batch: true);
 await rebels.RemoveAsync(rebel);
 var rebel = await rebels.FindAsync(id);
 var rebel = await rebels.FindAsync(id, withConflicts: true);
@@ -400,7 +398,7 @@ await _rebels.FindAsync("1", new FindOptions { Rev = "1-xxx" });
 await _rebels.AddOrUpdateAsync(r, new AddOrUpdateOptions { Rev = "1-xxx" });
 ```
 
-For attachements revisions are supported by 'CouchAttachment' class which is passing 'DocumentRev' to 'DownloadAttachmentAsync(..)' and 'DownloadAttachmentAsStreamAsync(..)'.
+For attachements revisions are supported by `CouchAttachment` class which is passing `DocumentRev` to `DownloadAttachmentAsync(..)` and `DownloadAttachmentAsStreamAsync(..)`.
 
 ## DB Changes Feed
 

--- a/README.md
+++ b/README.md
@@ -268,7 +268,9 @@ var tasks = await client.GetActiveTasksAsync();
 ```csharp
 // CRUD
 await rebels.AddAsync(rebel);
+await rebels.AddAsync(rebel, batch: true);
 await rebels.AddOrUpdateAsync(rebel);
+await rebels.AddOrUpdateAsync(rebel, batch: true);
 await rebels.RemoveAsync(rebel);
 var rebel = await rebels.FindAsync(id);
 var rebel = await rebels.FindAsync(id, withConflicts: true);
@@ -388,6 +390,19 @@ string downloadFilePath = await rebels.DownloadAttachment(attachment, downloadFo
 //or
 Stream responseStream = await rebels.DownloadAttachmentAsStreamAsync(attachment);
 ```
+
+## Revisions
+
+The options for 'FindAsync(..)' and 'AddOrUpdateAsync(..)' support passing revision:
+
+```csharp
+await _rebels.FindAsync("1", new FindOptions { Rev = "1-xxx" });
+await _rebels.AddOrUpdateAsync(r, new AddOrUpdateOptions { Rev = "1-xxx" });
+```
+
+Options also can be used to pass 'Batch', 'Conflicts' where applicable.
+
+For attachements revisions are supported by 'CouchAttachment' class which is passing 'DocumentRev' to 'DownloadAttachmentAsync(..)' and 'DownloadAttachmentAsStreamAsync(..)'.
 
 ## DB Changes Feed
 

--- a/src/CouchDB.Driver/DatabaseApiMethodOptions/AddOptions.cs
+++ b/src/CouchDB.Driver/DatabaseApiMethodOptions/AddOptions.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CouchDB.Driver.DatabaseApiMethodOptions
+{
+    /// <summary>
+    /// Options relevant to saving a new document (supported by both PUT /{db}/{docid} and POST /{db}).
+    /// Check https://docs.couchdb.org/en/stable/api/database/common.html#post--db
+    /// Check https://docs.couchdb.org/en/stable/api/document/common.html#put--db-docid
+    /// </summary>
+    public class AddOptions
+    {
+        /// <summary>
+        /// Stores document in batch mode. Check https://docs.couchdb.org/en/stable/api/database/common.html#api-doc-batch-writes
+        /// </summary>
+        public bool Batch { get; set; } = false;
+    }
+}

--- a/src/CouchDB.Driver/DatabaseApiMethodOptions/AddOrUpdateOptions.cs
+++ b/src/CouchDB.Driver/DatabaseApiMethodOptions/AddOrUpdateOptions.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CouchDB.Driver.DatabaseApiMethodOptions
+{
+    /// <summary>
+    /// Options relevant to saving a document (supported by PUT HTTP-method).
+    /// Check https://docs.couchdb.org/en/stable/api/document/common.html#put--db-docid
+    /// </summary>
+    public class AddOrUpdateOptions
+    {
+        /// <summary>
+        /// Stores document in batch mode. Check https://docs.couchdb.org/en/stable/api/database/common.html#api-doc-batch-writes
+        /// </summary>
+        public bool Batch { get; set; } = false;
+
+        /// <summary>
+        /// Document’s revision if updating an existing document.
+        /// </summary>
+        public string? Rev { get; set; }
+    }
+}

--- a/src/CouchDB.Driver/DatabaseApiMethodOptions/FindOptions.cs
+++ b/src/CouchDB.Driver/DatabaseApiMethodOptions/FindOptions.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CouchDB.Driver.DatabaseApiMethodOptions
+{
+    /// <summary>
+    /// Options relevant to getting a document (supported by GET HTTP-method).
+    /// Check https://docs.couchdb.org/en/stable/api/document/common.html#get--db-docid
+    /// </summary>
+    public class FindOptions
+    {
+        /// <summary>
+        /// Includes information about conflicts in document. Default is false
+        /// </summary>
+        public bool Conflicts { get; set; } = false;
+
+        /// <summary>
+        /// Retrieves document of specified revision. Optional
+        /// </summary>
+        public string? Rev { get; set; }
+    }
+}

--- a/src/CouchDB.Driver/ICouchDatabase.cs
+++ b/src/CouchDB.Driver/ICouchDatabase.cs
@@ -8,6 +8,7 @@ using CouchDB.Driver.ChangesFeed;
 using CouchDB.Driver.ChangesFeed.Responses;
 using CouchDB.Driver.Indexes;
 using CouchDB.Driver.Local;
+using CouchDB.Driver.DatabaseApiMethodOptions;
 using CouchDB.Driver.Security;
 using CouchDB.Driver.Types;
 using CouchDB.Driver.Views;
@@ -30,6 +31,15 @@ namespace CouchDB.Driver
         /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the element found, or null.</returns>
         Task<TSource?> FindAsync(string docId, bool withConflicts = false, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Finds the document with the given ID. If no document is found, then null is returned.
+        /// </summary>
+        /// <param name="docId">The document ID.</param>
+        /// <param name="options">Set of options available for GET /{db}/{docid}</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the element found, or null</returns>
+        Task<TSource?> FindAsync(string docId, FindOptions options, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Finds all documents matching the MangoQuery.
@@ -65,6 +75,15 @@ namespace CouchDB.Driver
         Task<TSource> AddAsync(TSource document, bool batch = false, CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Creates a new document and returns it.
+        /// </summary>
+        /// <param name="document">The document to create.</param>
+        /// <param name="options">Set of options available for both PUT /{db}/{docid} and POST /{db}</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the element created.</returns>
+        Task<TSource> AddAsync(TSource document, AddOptions options, CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Creates or updates the document with the given ID.
         /// </summary>
         /// <param name="document">The document to create or update</param>
@@ -72,6 +91,15 @@ namespace CouchDB.Driver
         /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the element created or updated.</returns>
         Task<TSource> AddOrUpdateAsync(TSource document, bool batch = false, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Creates or updates the document with the given ID.
+        /// </summary>
+        /// <param name="document">The document to create or update</param>
+        /// <param name="options">Set of options available for PUT /{db}/{docid}</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the element created or updated.</returns>
+        Task<TSource> AddOrUpdateAsync(TSource document, AddOrUpdateOptions options, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Deletes the document with the given ID.

--- a/tests/CouchDB.Driver.E2ETests/README.txt
+++ b/tests/CouchDB.Driver.E2ETests/README.txt
@@ -1,0 +1,6 @@
+﻿You need a CouchDB database engine running on http://localhost:5984/.
+
+If you have a docker execute:
+```
+docker run -p 5984:5984 -e COUCHDB_USER=admin -e COUCHDB_PASSWORD=admin -d couchdb
+```


### PR DESCRIPTION
Revisions are essential feature for MVCC in CouchDB. Passing a revision to PUT request makes you aware of the conflict (if happen) via response [409 Conflict](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.10) from CouchDB HTTP API. That's why we need to support passing revisions to `AddOrUpdate` method.

To avoid breaking changes with my addition and while more request options might be introduced in future, I contributed to `DatabaseApiMethodOptions` namespace and:
  - added `FindOptions` + `ICouchDatabase<TSource>.FindAsync` paired method
  - added `AddOrUpdateOptions` + `ICouchDatabase<TSource>.AddOrUpdateAsync` paired method 
  - added `AddOptions` + `ICouchDatabase<TSource>.AddAsync` paired method

I suppose in the future another contributors whould't extend method parameters, instead add properties to `DatabaseApiMethodOptions.*Options` objects.

Unit-tests covering new options are added.

I checked and see that for attachements revisions are already supported by `CouchAttachment` class which is passing `DocumentRev` to `DownloadAttachmentAsync(..)` and `DownloadAttachmentAsStreamAsync(..)`.

Added "Revisions" section to README.