### PR TITLE
Implements fetching attachment data when requested in continuous change feed

### DIFF
--- a/src/CouchDB.Driver/CouchDatabase.cs
+++ b/src/CouchDB.Driver/CouchDatabase.cs
@@ -414,6 +414,7 @@ namespace CouchDB.Driver
         public async Task<ChangesFeedResponse<TSource>> GetChangesAsync(ChangesFeedOptions? options = null, ChangesFeedFilter? filter = null, CancellationToken cancellationToken = default)
         {
             IFlurlRequest request = NewRequest()
+                .WithHeader("Accept", "application/json")
                 .AppendPathSegment("_changes");
 
             if (options?.LongPoll == true)
@@ -448,6 +449,7 @@ namespace CouchDB.Driver
             var infiniteTimeout = TimeSpan.FromMilliseconds(Timeout.Infinite);
             IFlurlRequest request = NewRequest()
                 .WithTimeout(infiniteTimeout)
+                .WithHeader("Accept", "application/json")
                 .AppendPathSegment("_changes")
                 .SetQueryParam("feed", "continuous");
 

--- a/src/CouchDB.Driver/CouchDatabase.cs
+++ b/src/CouchDB.Driver/CouchDatabase.cs
@@ -81,6 +81,7 @@ namespace CouchDB.Driver
         public async Task<TSource?> FindAsync(string docId, FindOptions options, CancellationToken cancellationToken = default)
         {
             IFlurlRequest request = NewRequest()
+                    .WithHeader("Accept", "application/json")
                     .AppendPathSegment(Uri.EscapeDataString(docId));
 
             IFlurlResponse? response = await SetFindOptions(request, options)

--- a/src/CouchDB.Driver/ICouchDatabase.cs
+++ b/src/CouchDB.Driver/ICouchDatabase.cs
@@ -222,7 +222,7 @@ namespace CouchDB.Driver
         /// <param name="cancellationToken">A cancellation token to stop receiving changes.</param>
         /// <returns>A IAsyncEnumerable that represents the asynchronous operation. The task result contains the feed change.</returns>
         IAsyncEnumerable<ChangesFeedResponseResult<TSource>> GetContinuousChangesAsync(
-            ChangesFeedOptions options, ChangesFeedFilter filter,
+            ChangesFeedOptions? options, ChangesFeedFilter? filter,
             CancellationToken cancellationToken);
 
         /// <summary>

--- a/src/CouchDB.Driver/Types/CouchAttachment.cs
+++ b/src/CouchDB.Driver/Types/CouchAttachment.cs
@@ -6,6 +6,9 @@ using Newtonsoft.Json;
 
 namespace CouchDB.Driver.Types
 {
+    /// <summary>
+    ///     Represents an attachment for a document.
+    /// </summary>
     public sealed class CouchAttachment
     {
         [JsonIgnore]
@@ -26,25 +29,78 @@ namespace CouchDB.Driver.Types
         [JsonIgnore]
         public Uri Uri { get; internal set; }
 
+        /// <summary>
+        ///     Gets whether the attachment object contains stub info and no content. 
+        /// </summary>
         [DataMember]
         [JsonProperty("stub")]
         public bool Stub { get; set; }
 
+        /// <summary>
+        ///     Gets the attachment MIME type.
+        /// </summary>
         [DataMember]
         [JsonProperty("content_type")]
         public string ContentType { get; set; }
 
+        /// <summary>
+        ///     Gets the content hash digest. It starts with prefix which announce hash type (md5-) and continues with
+        ///     Base64-encoded hash digest.
+        /// </summary>
         [DataMember]
         [JsonProperty("digest")]
         public string Digest { get; private set; }
 
+        /// <summary>
+        ///     Gets the real attachment size in bytes. Not available if attachment content requested.
+        /// </summary>
         [DataMember]
         [JsonProperty("length")]
-        public int? Length { get; private set; }
+        public long? Length { get; private set; }
 
+        /// <summary>
+        ///     Gets the revision number when attachment was added.
+        /// </summary>
         [DataMember]
         [JsonProperty("revpos")]
         public int? RevPos { get; private set; }
+
+        /// <summary>
+        ///     Gets the compressed attachment size in bytes.
+        /// </summary>
+        /// <remarks>
+        ///     Available if content_type is in list of compressible types when the attachment was added and the following query
+        ///     parameters are specified:
+        ///     <list type="bullet">
+        ///         <item>
+        ///             <description>att_encoding_info=true when querying a document</description>
+        ///         </item>
+        ///         <item>
+        ///             <description>att_encoding_info=true&amp;include_docs=true when querying a changes feed or a view</description>
+        ///         </item>
+        ///     </list>
+        /// </remarks>
+        [DataMember]
+        [JsonProperty("encoded_length")]
+        public long? EncodedLength { get; private set; }
+
+        /// <summary>
+        ///     Gets the Base64-encoded content. Only populated if queried for and <see cref="Stub"/> is false.
+        /// </summary>
+        /// <remarks>
+        ///     Base64-encoded content. Available if attachment content is requested by using the following query parameters:
+        ///     <list type="bullet">
+        ///         <item>
+        ///             <description>attachments=true when querying a document</description>
+        ///         </item>
+        ///         <item>
+        ///             <description>attachments=true&amp;include_docs=true when querying a changes feed or a view</description>
+        ///         </item>
+        ///     </list>
+        /// </remarks>
+        [DataMember]
+        [JsonProperty("data")]
+        public int? Data { get; private set; }
     }
 }
 #nullable restore

--- a/src/CouchDB.Driver/Types/CouchAttachment.cs
+++ b/src/CouchDB.Driver/Types/CouchAttachment.cs
@@ -100,7 +100,7 @@ namespace CouchDB.Driver.Types
         /// </remarks>
         [DataMember]
         [JsonProperty("data")]
-        public int? Data { get; private set; }
+        public string Data { get; private set; }
     }
 }
 #nullable restore

--- a/src/azure-pipelines.yaml
+++ b/src/azure-pipelines.yaml
@@ -1,6 +1,6 @@
 variables:
   BuildConfiguration: Release
-  PackageVersion: '3.4.0'
+  PackageVersion: '3.5.0'
 
 trigger:
   branches:


### PR DESCRIPTION
## Summary

This fixes #194. When a user requests the full document and attachments to be included in the change feed response, the Base64 encoded data blob of the attachment is now returned so the document can be inserted unaltered into a different database.

I think the chosen approach both conserves backwards compatibility and makes the change feed behave as expected.

## Changes

- Added XML documentation to `CouchAttachment` class
- Changed `int` to `long` to support attachments greater than the Int32 size limitation
- Added missing properties to `CouchAttachment` class:
  - `EncodedLength `
  - `Data` 
- Added HTTP header `Accept: application/json` where applicable
- Fixed a nullable warning

## Open TODOs

- Add tests
