### PR TITLE
Fixed infinite loop in GetChangesAsync

### DIFF
--- a/src/CouchDB.Driver/CouchDatabase.cs
+++ b/src/CouchDB.Driver/CouchDatabase.cs
@@ -459,6 +459,8 @@ namespace CouchDB.Driver
                 request = request.ApplyQueryParametersOptions(options);
             }
 
+            var lastSequence = options?.Since ?? "0";
+
             do
             {
                 await using Stream stream = filter == null
@@ -466,9 +468,7 @@ namespace CouchDB.Driver
                         .ConfigureAwait(false)
                     : await request.QueryContinuousWithFilterAsync<TSource>(_queryProvider, filter, cancellationToken)
                         .ConfigureAwait(false);
-
-                var lastSequence = options?.Since ?? "0";
-
+                
                 await foreach (var line in stream.ReadLinesAsync(cancellationToken))
                 {
                     if (string.IsNullOrEmpty(line))


### PR DESCRIPTION
In #200 I unfortunately botched the implementation; once the loop restarts, the `lastSequence` is overwritten with the `since` option which if provided `0` causes and endless loop going through all changes ever forever.

This PR fixes this by moving the variable assignment to the proper location outside of the loop.