### PR TITLE
Fix for IncludeExecutionStats causing an exception

### DIFF
--- a/src/CouchDB.Driver/Types/ExecutionStats.cs
+++ b/src/CouchDB.Driver/Types/ExecutionStats.cs
@@ -35,6 +35,6 @@ namespace CouchDB.Driver.Types
         /// Total execution time in milliseconds as measured by the database.
         /// </summary>
         [JsonProperty("execution_time_ms")]
-        public int ExecutionTimeMs { get; internal set; }
+        public float ExecutionTimeMs { get; internal set; }
     }
 }


### PR DESCRIPTION
Using IncludeExecutionStats causes an exception because the value for execution_time_ms is specified as an integer but couchdb sends it as a decimal number. This causes a JSON deserialization exception.
