### PR TITLE
Added ThrowOnQueryWarning option

### DIFF
--- a/src/CouchDB.Driver/CouchClient.cs
+++ b/src/CouchDB.Driver/CouchClient.cs
@@ -112,19 +112,19 @@ namespace CouchDB.Driver
         public ICouchDatabase<TSource> GetDatabase<TSource>(string database, string? discriminator = null) where TSource : CouchDocument
         {
             CheckDatabaseName(database);
-            var queryContext = new QueryContext(Endpoint, database);
+            var queryContext = new QueryContext(Endpoint, database, _options.ThrowOnQueryWarning);
             return new CouchDatabase<TSource>(_flurlClient, _options, queryContext, discriminator);
         }
 
         /// <inheritdoc />
-        public async Task<ICouchDatabase<TSource>> CreateDatabaseAsync<TSource>(string database, 
+        public async Task<ICouchDatabase<TSource>> CreateDatabaseAsync<TSource>(string database,
             int? shards = null, int? replicas = null, bool? partitioned = null, string? discriminator = null, CancellationToken cancellationToken = default)
             where TSource : CouchDocument
         {
             QueryContext queryContext = NewQueryContext(database);
             IFlurlResponse response = await CreateDatabaseAsync(queryContext, shards, replicas, partitioned, cancellationToken)
                 .ConfigureAwait(false);
-            
+
             if (response.IsSuccessful())
             {
                 return new CouchDatabase<TSource>(_flurlClient, _options, queryContext, discriminator);
@@ -167,7 +167,7 @@ namespace CouchDB.Driver
                 .SendRequestAsync()
                 .ConfigureAwait(false);
 
-            if (!result.Ok) 
+            if (!result.Ok)
             {
                 throw new CouchException("Something went wrong during the delete.", null, "S");
             }
@@ -433,7 +433,7 @@ namespace CouchDB.Driver
         private QueryContext NewQueryContext(string database)
         {
             CheckDatabaseName(database);
-            return new QueryContext(Endpoint, database);
+            return new QueryContext(Endpoint, database, _options.ThrowOnQueryWarning);
         }
 
         private void CheckDatabaseName(string database)

--- a/src/CouchDB.Driver/DTOs/FindResult.cs
+++ b/src/CouchDB.Driver/DTOs/FindResult.cs
@@ -16,6 +16,9 @@ namespace CouchDB.Driver.DTOs
 
         [JsonProperty("execution_stats")]
         public ExecutionStats ExecutionStats { get; internal set; }
+
+        [JsonProperty("warning")]
+        public string Warning { get; internal set; }
     }
 }
 #nullable restore

--- a/src/CouchDB.Driver/Exceptions/CouchDBQueryWarningException.cs
+++ b/src/CouchDB.Driver/Exceptions/CouchDBQueryWarningException.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace CouchDB.Driver.Exceptions
+{
+    /// <summary>
+    /// The exception that is thrown if the query returns a warning.
+    /// </summary>
+    public class CouchDBQueryWarningException : Exception
+    {
+        public CouchDBQueryWarningException(string message) : base(message) { }
+    }
+}

--- a/src/CouchDB.Driver/Options/CouchOptions.cs
+++ b/src/CouchDB.Driver/Options/CouchOptions.cs
@@ -27,13 +27,15 @@ namespace CouchDB.Driver.Options
         internal bool PluralizeEntities { get; set; }
         internal DocumentCaseType DocumentsCaseType { get; set; }
         internal PropertyCaseType PropertiesCase { get; set; }
-        
+
         internal string? DatabaseSplitDiscriminator { get; set; }
         internal NullValueHandling? NullValueHandling { get; set; }
         internal bool LogOutOnDispose { get; set; }
 
         internal Func<HttpRequestMessage, X509Certificate2, X509Chain, SslPolicyErrors, bool>? ServerCertificateCustomValidationCallback { get; set; }
         internal Action<ClientFlurlHttpSettings>? ClientFlurlHttpSettingsAction { get; set; }
+
+        internal bool ThrowOnQueryWarning { get; set; }
 
         internal CouchOptions()
         {

--- a/src/CouchDB.Driver/Options/CouchOptionsBuilder.cs
+++ b/src/CouchDB.Driver/Options/CouchOptionsBuilder.cs
@@ -95,6 +95,12 @@ namespace CouchDB.Driver.Options
             return this;
         }
 
+        public virtual CouchOptionsBuilder ThrowOnQueryWarning()
+        {
+            Options.ThrowOnQueryWarning = true;
+            return this;
+        }
+
         /// <summary>
         /// Enables cookie authentication. 
         /// For cookie authentication (RFC 2109) CouchDB generates a token that the client can use for the next few requests to CouchDB. Tokens are valid until a timeout.

--- a/src/CouchDB.Driver/Query/QueryContext.cs
+++ b/src/CouchDB.Driver/Query/QueryContext.cs
@@ -8,11 +8,14 @@ namespace CouchDB.Driver.Query
         public string DatabaseName { get; set; }
         public string EscapedDatabaseName { get; set; }
 
-        public QueryContext(Uri endpoint, string databaseName)
+        public bool ThrowOnQueryWarning { get; set; }
+
+        public QueryContext(Uri endpoint, string databaseName, bool throwOnQueryWarning)
         {
             Endpoint = endpoint;
             DatabaseName = databaseName;
             EscapedDatabaseName = Uri.EscapeDataString(databaseName);
+            ThrowOnQueryWarning = throwOnQueryWarning;
         }
     }
 }

--- a/tests/CouchDB.Driver.E2ETests/Client_Tests.cs
+++ b/tests/CouchDB.Driver.E2ETests/Client_Tests.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using CouchDB.Driver.E2ETests;
 using CouchDB.Driver.E2ETests.Models;
+using CouchDB.Driver.Exceptions;
 using CouchDB.Driver.Extensions;
 using CouchDB.Driver.Local;
 using Xunit;
@@ -13,7 +14,7 @@ using Xunit;
 namespace CouchDB.Driver.E2E
 {
     [Trait("Category", "Integration")]
-    public class ClientTests: IAsyncLifetime
+    public class ClientTests : IAsyncLifetime
     {
         private ICouchClient _client;
         private ICouchDatabase<Rebel> _rebels;
@@ -152,7 +153,7 @@ namespace CouchDB.Driver.E2E
         public async Task Users()
         {
             var users = await _client.GetOrCreateUsersDatabaseAsync();
-            
+
             CouchUser luke = await users.AddAsync(new CouchUser(name: "luke", password: "lasersword"));
             Assert.Equal("luke", luke.Name);
 
@@ -265,6 +266,42 @@ namespace CouchDB.Driver.E2E
             var docs = await local.GetAsync(searchOpt);
             var containsId = docs.Select(d => d.Id).Contains("_local/" + docId);
             Assert.True(containsId);
+        }
+
+        [Fact]
+        public async Task ThrowOnQueryWarning()
+        {
+            await using var context = new MyDeathStarContextWithQueryWarning();
+            // There is an index for Name and Surname so it should not cause a warning
+            await context.Rebels.Where(r => r.Name == "Luke" && r.Surname == "Skywalker").ToListAsync();
+            try
+            {
+                // There is no index for Age so it should cause a warning
+                await context.Rebels.Where(r => r.Age == 19).ToListAsync();
+                Assert.Fail("Expected exception not thrown");
+            }
+            catch (CouchDBQueryWarningException e)
+            {
+                Assert.Equal("No matching index found, create an index to optimize query time.", e.Message);
+            }
+
+            var client = new CouchClient("http://localhost:5984", c =>
+                c.UseBasicAuthentication("admin", "admin")
+                    .ThrowOnQueryWarning());
+            var crebels = client.GetDatabase<Rebel>();
+            // There is an index for Name and Surname so it should not cause a warning
+            await crebels.QueryAsync(@"{""selector"":{""$and"":[{""name"":""Luke""},{""surname"":""Skywalker""}]}}");
+            try
+            {
+                // There is no index for Age so it should cause a warning
+                await crebels.QueryAsync(@"{""selector"":{""age"":""19""}}");
+                Assert.Fail("Expected exception not thrown");
+            }
+            catch (CouchDBQueryWarningException e)
+            {
+                Assert.Equal("No matching index found, create an index to optimize query time.", e.Message);
+            }
+
         }
     }
 }

--- a/tests/CouchDB.Driver.E2ETests/MyDeathStarContext.cs
+++ b/tests/CouchDB.Driver.E2ETests/MyDeathStarContext.cs
@@ -1,4 +1,4 @@
-﻿using CouchDB.Driver.E2ETests.Models;
+using CouchDB.Driver.E2ETests.Models;
 using CouchDB.Driver.Options;
 
 namespace CouchDB.Driver.E2ETests
@@ -48,4 +48,27 @@ namespace CouchDB.Driver.E2ETests
                     .ThenByDescending(r => r.Name));
         }
     }
+
+    public class MyDeathStarContextWithQueryWarning : CouchContext
+    {
+        public CouchDatabase<Rebel> Rebels { get; set; }
+
+        protected override void OnConfiguring(CouchOptionsBuilder optionsBuilder)
+        {
+            optionsBuilder
+                    .UseEndpoint("http://localhost:5984/")
+                    .EnsureDatabaseExists()
+                    .UseBasicAuthentication(username: "admin", password: "admin")
+                    .ThrowOnQueryWarning();
+        }
+
+        protected override void OnDatabaseCreating(CouchDatabaseBuilder databaseBuilder)
+        {
+            databaseBuilder.Document<Rebel>()
+                    .HasIndex("surnames_index", builder => builder
+                            .IndexBy(r => r.Surname)
+                            .ThenBy(r => r.Name));
+        }
+    }
+
 }


### PR DESCRIPTION
CouchDB has the handy ability to return warnings on mango queries. Most often it is a notification that the query could not find a suitable index, which of course is terrible for performance. However it is easy to miss this valuable information.

This patch adds a "Warning" property to FindResult and also the option to throw an exception if there a warning present on the FindResult. 

This needs to be explicitly enabled by using ThrowOnQueryWarning() on the OptionsBuilder so it does not impact any existing code.

My personal intention for this feature it to enable it only in development so that if any of my tests cause a query that generates a warning then the test will fail and I can correct the problem (mostly likely by adding an appropriate index) before the issue makes it to production.

Could also be used in production if you are careful to catch the exception and do something with it, presumably log it somewhere that someone will actually see it.
