### PR TITLE
#217 Fix Select projections of _id and scalar fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 4.1.1 (2026-06-17)
+
+## Bugs
+
+* **Find queries**: `Select` projections now deserialize correctly. `_id`/`_rev` are mapped to `Id`/`Rev` in anonymous projections (e.g. `Select(x => new { x.Id })`), and scalar member projections (e.g. `Select(x => x.Id)`, `Select(x => x.Name)`, `Select(x => x.Age)`) now return the selected field's value instead of throwing during deserialization. ([#217](https://github.com/matteobortolazzo/couchdb-net/issues/217))
+
 # 4.1.0 (2026-06-15)
 
 ## Bugs

--- a/LATEST_CHANGE.md
+++ b/LATEST_CHANGE.md
@@ -1,11 +1,5 @@
-# 4.1.0
+# 4.1.1
 
 ## Bugs
 
-* **Find queries**: `_id` and `_rev` fields from CouchDB `_find` responses are now correctly mapped to `Id` and `Rev` properties on result documents. Previously, these fields were silently dropped during deserialization. ([#219](https://github.com/matteobortolazzo/couchdb-net/pull/219), based on [#218](https://github.com/matteobortolazzo/couchdb-net/pull/218)) Thanks [@gchiappe](https://github.com/gchiappe)
-* **Active tasks**: Fixed `GetActiveTasksAsync()` throwing `InvalidOperationException` at runtime due to `UnixTimestampSecondsConverter` type mismatch with `ActiveTask.StartedOn`/`UpdatedOn` properties ([#219](https://github.com/matteobortolazzo/couchdb-net/pull/219))
-* **Changes feed**: Fixed `ReceiveStream()` prematurely disposing the HTTP response content stream when using POST-based continuous change feed filters ([#219](https://github.com/matteobortolazzo/couchdb-net/pull/219))
-
-## Improvements
-
-* Extracted shared `DocumentRewriter` for `_id`/`_rev` property rewriting, used by both `FindResultConverter` and `ReadItemResponseConverter`
+* **Find queries**: `Select` projections now deserialize correctly. `_id`/`_rev` are mapped to `Id`/`Rev` in anonymous projections (e.g. `Select(x => new { x.Id })`), and scalar member projections (e.g. `Select(x => x.Id)`, `Select(x => x.Name)`, `Select(x => x.Age)`) now return the selected field's value instead of throwing during deserialization. ([#217](https://github.com/matteobortolazzo/couchdb-net/issues/217))

--- a/src/CouchDB.Driver/Converters/FindResultConverter.cs
+++ b/src/CouchDB.Driver/Converters/FindResultConverter.cs
@@ -25,7 +25,6 @@ internal class FindResultConverterFactory : JsonConverterFactory
 }
 
 internal class FindResultConverter<TItem> : JsonConverter<FindResult<TItem>>
-    where TItem : class
 {
     public override FindResult<TItem> Read(ref Utf8JsonReader reader, Type typeToConvert,
         JsonSerializerOptions options)
@@ -90,6 +89,8 @@ internal class FindResultConverter<TItem> : JsonConverter<FindResult<TItem>>
             throw new JsonException("Expected start of array");
         }
 
+        var isScalarProjection = IsScalarProjection(typeof(TItem));
+
         var items = new List<TItem>();
         while (reader.Read())
         {
@@ -98,9 +99,67 @@ internal class FindResultConverter<TItem> : JsonConverter<FindResult<TItem>>
                 break;
             }
 
-            items.Add(DocumentRewriter.RewriteDocument<TItem>(ref reader, options));
+            items.Add(isScalarProjection
+                ? ReadScalarDocument(ref reader, options)
+                : DocumentRewriter.RewriteDocument<TItem>(ref reader, options));
         }
 
         return items.ToArray();
+    }
+
+    /// <summary>
+    /// Reads a scalar projection such as <c>Select(x =&gt; x.Id)</c>. The server returns each
+    /// document as an object with a single field (e.g. <c>{"_id":"abc"}</c>); the value of that
+    /// field is deserialized into <typeparamref name="TItem"/>, ignoring the property name so
+    /// that <c>_id</c>, <c>_rev</c> and any other selected field are handled uniformly.
+    /// </summary>
+    private static TItem ReadScalarDocument(ref Utf8JsonReader reader, JsonSerializerOptions options)
+    {
+        if (reader.TokenType != JsonTokenType.StartObject)
+        {
+            throw new JsonException("Expected start of object");
+        }
+
+        TItem result = default!;
+        var found = false;
+
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.EndObject)
+            {
+                break;
+            }
+
+            if (reader.TokenType != JsonTokenType.PropertyName)
+            {
+                throw new JsonException("Expected property name");
+            }
+
+            reader.Read();
+
+            if (found)
+            {
+                reader.Skip();
+                continue;
+            }
+
+            result = JsonSerializer.Deserialize<TItem>(ref reader, options)!;
+            found = true;
+        }
+
+        return result;
+    }
+
+    private static bool IsScalarProjection(Type type)
+    {
+        type = Nullable.GetUnderlyingType(type) ?? type;
+        return type == typeof(string)
+               || type.IsPrimitive
+               || type.IsEnum
+               || type == typeof(Guid)
+               || type == typeof(DateTime)
+               || type == typeof(DateTimeOffset)
+               || type == typeof(decimal)
+               || type == typeof(TimeSpan);
     }
 }

--- a/tests/CouchDB.Driver.UnitTests/Find/Find_Projection_Tests.cs
+++ b/tests/CouchDB.Driver.UnitTests/Find/Find_Projection_Tests.cs
@@ -1,0 +1,86 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using CouchDB.Driver.Extensions;
+using CouchDB.Driver.UnitTests._Helpers;
+using Xunit;
+
+namespace CouchDB.Driver.UnitTests.Find;
+
+public class Find_Projection_Tests : HttpTests
+{
+    #region Anonymous projections (regression - already fixed by FindResult converter)
+
+    [Fact]
+    public async Task Select_AnonymousId_MapsId()
+    {
+        HttpTest.RespondWith("""{"docs":[{"_id":"abc"}],"bookmark":"bm"}""");
+
+        var result = await Rebels.Select(x => new { x.Id }).ToListAsync();
+
+        Assert.Single(result);
+        Assert.Equal("abc", result[0].Id);
+    }
+
+    [Fact]
+    public async Task Select_AnonymousIdRev_MapsIdAndRev()
+    {
+        HttpTest.RespondWith("""{"docs":[{"_id":"abc","_rev":"1-xyz"}],"bookmark":"bm"}""");
+
+        var result = await Rebels.Select(x => new { x.Id, x.Rev }).ToListAsync();
+
+        Assert.Single(result);
+        Assert.Equal("abc", result[0].Id);
+        Assert.Equal("1-xyz", result[0].Rev);
+    }
+
+    [Fact]
+    public async Task Select_AnonymousIdAndField_MapsAll()
+    {
+        HttpTest.RespondWith("""{"docs":[{"_id":"abc","name":"Luke"}],"bookmark":"bm"}""");
+
+        var result = await Rebels.Select(x => new { x.Id, x.Name }).ToListAsync();
+
+        Assert.Single(result);
+        Assert.Equal("abc", result[0].Id);
+        Assert.Equal("Luke", result[0].Name);
+    }
+
+    #endregion
+
+    #region Scalar projections (the fix)
+
+    [Fact]
+    public async Task Select_ScalarId_ReturnsIds()
+    {
+        HttpTest.RespondWith("""{"docs":[{"_id":"abc"},{"_id":"def"}],"bookmark":"bm"}""");
+
+        var result = await Rebels.Select(x => x.Id).ToListAsync();
+
+        Assert.Equal(["abc", "def"], result);
+    }
+
+    [Fact]
+    public async Task Select_ScalarName_ReturnsNames()
+    {
+        HttpTest.RespondWith("""{"docs":[{"name":"Luke"},{"name":"Leia"}],"bookmark":"bm"}""");
+
+        var result = await Rebels.Select(x => x.Name).ToListAsync();
+
+        Assert.Equal(["Luke", "Leia"], result);
+    }
+
+    [Fact]
+    public void Select_ScalarValueType_ReturnsValues()
+    {
+        HttpTest.RespondWith("""{"docs":[{"age":19},{"age":21}],"bookmark":"bm"}""");
+
+        // Value-type projections cannot use ToListAsync (constrained to reference types),
+        // so they materialize through synchronous enumeration.
+        List<int> result = Rebels.Select(x => x.Age).ToList();
+
+        Assert.Equal([19, 21], result);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
Fixes #217.

## Problem

`db.Select(x => new { x.Id }).ToListAsync()` returned rows with a null/empty `Id`, and the scalar form `Select(x => x.Id)` threw during deserialization — even though the generated Mango query (`{"fields":["_id"],"selector":{}}`) was correct.

For a terminal `.Select(...).ToListAsync()`, `Select` is not in the `Composite` list, so `QueryCompiler` deserializes the `_find` response **directly into the projected type** (`FindResult<AnonymousType>` / `FindResult<string>`), not the document type.

- **Anonymous projections** (`Select(x => new { x.Id })`) already worked via #219's `DocumentRewriter`, but had **no test coverage**.
- **Scalar projections** (`Select(x => x.Id)`, `x.Name`, `x.Age`) were broken: the converter rewrote the doc object `{"_id":"abc"}` and tried to deserialize it into `string`/`int`, throwing. Value-type scalars failed even earlier because `FindResultConverter<TItem>` was constrained `where TItem : class`.

## Fix

`src/CouchDB.Driver/Converters/FindResultConverter.cs`:
- Removed the `where TItem : class` constraint so value-type scalars (`int`, `enum`, `Guid`, …) get a converter.
- `ReadDocs` now branches: scalar projections deserialize the **single field's value** (ignoring the property name, so `_id`/`_rev`/any field work uniformly); complex types keep the existing `DocumentRewriter` path unchanged.
- Added `IsScalarProjection(Type)` helper.

## Tests

New `tests/CouchDB.Driver.UnitTests/Find/Find_Projection_Tests.cs`:
- 3 anonymous-projection regression tests (`new { x.Id }`, `new { x.Id, x.Rev }`, `new { x.Id, x.Name }`).
- 3 scalar tests (`Select(x => x.Id)`, `Select(x => x.Name)`, value-type `Select(x => x.Age).ToList()`).

Full unit suite: 198 passing.

## Out of scope

Value-type **async** projections (`Select(x => x.Age).ToListAsync()`) don't compile because `ToListAsync` is constrained `where TSource : class`. Value-type scalars are reachable via synchronous enumeration, which this fix covers. Relaxing that constraint would be a broader API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)